### PR TITLE
Correcting splash-screen behavior

### DIFF
--- a/XrmToolBox/MainForm.Designer.cs
+++ b/XrmToolBox/MainForm.Designer.cs
@@ -439,7 +439,7 @@ namespace XrmToolBox
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "XrmToolBox for Microsoft Dynamics CRM 2011/2013/2015";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
-            this.Load += new System.EventHandler(this.Form1Load);
+            this.Load += new System.EventHandler(this.MainForm_Load);
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();
             this.tabControl1.ResumeLayout(false);

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -23,6 +23,7 @@ using XrmToolBox.AppCode;
 using XrmToolBox.Attributes;
 using XrmToolBox.Forms;
 using XrmToolBox.UserControls;
+using System.Threading.Tasks;
 
 namespace XrmToolBox
 {
@@ -62,10 +63,10 @@ namespace XrmToolBox
             currentOptions = Options.Load();
             Text = string.Format("{0} (v{1})", Text, Assembly.GetExecutingAssembly().GetName().Version);
 
-            Hide();
-            LaunchWelcomeMessage();
+            // Hide();
+            // LaunchWelcomeMessage();
             ManageConnectionControl();
-            Show();
+            // Show();
             CheckForNewVersion();
         }
 
@@ -180,10 +181,29 @@ namespace XrmToolBox
 
         #region Form events
 
-        private void Form1Load(object sender, EventArgs e)
+        private async void Form1Load(object sender, EventArgs e)
         {
-            pManager = new PluginManager();
-            pManager.LoadPlugins();
+            var tasks = new List<Task>();
+
+            tasks.Add(new Task(() =>
+                {
+                    pManager = new PluginManager();
+                    pManager.LoadPlugins();
+                }));
+
+            tasks.Add(new Task(() =>
+                {
+                    var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+                    var blackScreen = new WelcomeDialog(version) { StartPosition = FormStartPosition.CenterScreen };
+                    blackScreen.ShowDialog(this);
+                }));
+
+            foreach (var task in tasks)
+            {
+                task.Start();
+            }
+
+            await Task.WhenAny(tasks.ToArray());
 
             DisplayPlugins();
         }

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -63,35 +63,13 @@ namespace XrmToolBox
             currentOptions = Options.Load();
             Text = string.Format("{0} (v{1})", Text, Assembly.GetExecutingAssembly().GetName().Version);
 
-            // Hide();
-            // LaunchWelcomeMessage();
             ManageConnectionControl();
-            // Show();
             CheckForNewVersion();
         }
 
         #endregion Constructor
 
         #region Initialization methods
-
-        private void LaunchWelcomeMessage()
-        {
-            var welcomeWorker = new BackgroundWorker();
-            welcomeWorker.DoWork += (sender, e) =>
-            {
-                var version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-                var blackScreen = new WelcomeDialog(version) { StartPosition = FormStartPosition.CenterScreen };
-                blackScreen.ShowDialog();
-            };
-            welcomeWorker.RunWorkerCompleted += (sender, e) =>
-            {
-                if (e.Error != null)
-                {
-                    MessageBox.Show(e.Error.ToString());
-                }
-            };
-            welcomeWorker.RunWorkerAsync();
-        }
 
         private void ManageConnectionControl()
         {

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -158,7 +158,7 @@ namespace XrmToolBox
 
         #region Form events
 
-        private async void Form1Load(object sender, EventArgs e)
+        private async void MainForm_Load(object sender, EventArgs e)
         {
             var tasks = new List<Task>();
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -3,27 +3,26 @@
 // CODEPLEX: http://xrmtoolbox.codeplex.com
 // BLOG: http://mscrmtools.blogspot.com
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Web;
-using System.Windows.Forms;
 using McTools.Xrm.Connection;
 using McTools.Xrm.Connection.WinForms;
 using Microsoft.Xrm.Client;
 using Microsoft.Xrm.Client.Services;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Web;
+using System.Windows.Forms;
 using XrmToolBox.AppCode;
 using XrmToolBox.Attributes;
 using XrmToolBox.Forms;
 using XrmToolBox.UserControls;
-using System.Threading.Tasks;
 
 namespace XrmToolBox
 {


### PR DESCRIPTION
The splash-screen code was reorganized to avoid usage of `BackgroundWorker`. `async` and `await` approach was used instead.

The code waits whatever will be finished first: plugins loading or 3 seconds splash-screen display delay and continues form loading.