### PR TITLE
Correcting references to plugin dependencies

### DIFF
--- a/Plugins/MsCrmTools.MetadataDocumentGenerator/MsCrmTools.MetadataDocumentGenerator.csproj
+++ b/Plugins/MsCrmTools.MetadataDocumentGenerator/MsCrmTools.MetadataDocumentGenerator.csproj
@@ -49,14 +49,14 @@
   <ItemGroup>
     <Reference Include="GemBox.Document, Version=23.3.30.1104, Culture=neutral, PublicKeyToken=b1b72c69714d4847, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\GemBox Software\GemBox.Document 2.3\Bin\GemBox.Document.dll</HintPath>
+      <HintPath>..\..\packages\GemBox.Document.23.3.30.1040\lib\net30\GemBox.Document.dll</HintPath>
     </Reference>
     <Reference Include="GemBox.LicenseKey">
       <HintPath>..\..\..\..\GemBox.LicenseKey\GemBox.LicenseKey\bin\ReleaseObfuscated\GemBox.LicenseKey.dll</HintPath>
     </Reference>
     <Reference Include="GemBox.Spreadsheet, Version=37.3.30.1128, Culture=neutral, PublicKeyToken=b1b72c69714d4847, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\GemBox Software\GemBox.Spreadsheet 3.7\Bin\NET3X4X\GemBox.Spreadsheet.dll</HintPath>
+      <HintPath>..\..\packages\GemBox.Spreadsheet.37.3.30.1110\lib\net30\GemBox.Spreadsheet.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\..\Referenced Assemblies\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -150,7 +150,7 @@ xcopy /y "$(ProjectDir)bin\debug\MsCrmTools.MetadataDocumentGenerator.pdb" "$(So
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_ConfigurationName="Release" />
+      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Plugins/MsCrmTools.Translator/MsCrmTools.Translator.csproj
+++ b/Plugins/MsCrmTools.Translator/MsCrmTools.Translator.csproj
@@ -49,14 +49,14 @@
   <ItemGroup>
     <Reference Include="GemBox.Document, Version=23.3.30.1104, Culture=neutral, PublicKeyToken=b1b72c69714d4847, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\GemBox Software\GemBox.Document 2.3\Bin\GemBox.Document.dll</HintPath>
+      <HintPath>..\..\packages\GemBox.Document.23.3.30.1040\lib\net30\GemBox.Document.dll</HintPath>
     </Reference>
     <Reference Include="GemBox.LicenseKey">
       <HintPath>..\..\..\..\GemBox.LicenseKey\GemBox.LicenseKey\bin\ReleaseObfuscated\GemBox.LicenseKey.dll</HintPath>
     </Reference>
     <Reference Include="GemBox.Spreadsheet, Version=37.3.30.1128, Culture=neutral, PublicKeyToken=b1b72c69714d4847, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\GemBox Software\GemBox.Spreadsheet 3.7\Bin\NET3X4X\GemBox.Spreadsheet.dll</HintPath>
+      <HintPath>..\..\packages\GemBox.Spreadsheet.37.3.30.1110\lib\net30\GemBox.Spreadsheet.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\..\Referenced Assemblies\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -152,7 +152,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_ConfigurationName="Release" />
+      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Plugins/MsCrmTools.WebResourcesManager/MsCrmTools.WebResourcesManager.csproj
+++ b/Plugins/MsCrmTools.WebResourcesManager/MsCrmTools.WebResourcesManager.csproj
@@ -51,7 +51,7 @@
       <HintPath>..\..\..\..\..\ASSEMBLIES\Compressor\EcmaScript.NET.modified.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.TextEditor">
-      <HintPath>..\..\..\..\..\ASSEMBLIES\ICSharpCode.TextEditor.dll</HintPath>
+      <HintPath>..\..\packages\ICSharpCode.TextEditor.3.2.1.6466\lib\Net20\ICSharpCode.TextEditor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\..\Referenced Assemblies\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -294,7 +294,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" />
+      <UserProperties BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_ConfigurationName="Release" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Some plugins does not compile, since their dependencies are not installed to `Program Files`, but most of the needed assemblies are already present as `NuGet` packages within repository. Correcting links to make use `NuGet` files instead of `Program Files` ones.