### PR TITLE
Loading plugins in parallel at application start up

### DIFF
--- a/XrmToolBox/PluginManager.cs
+++ b/XrmToolBox/PluginManager.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace XrmToolBox
 {
@@ -53,7 +54,7 @@ namespace XrmToolBox
             {
                 var files = Directory.GetFileSystemEntries(directoryInfo.FullName, "*.dll");
 
-                foreach (var file in files)
+                Parallel.ForEach(files, file =>
                 {
                     try
                     {
@@ -94,7 +95,7 @@ namespace XrmToolBox
                             throw;
                         }// else eat it
                     }
-                }
+                });
             }
         }
 


### PR DESCRIPTION
Simple optimization to speed-up XrmToolBox loading.

I've made simple test on efficiency. I've run 10 times each approach on 24 plugins. Here is results:

Case no. | Serial execution (milliseconds)| Parallel execution (milliseconds)
--- | ---------------- | ------------------
1 | 398 | 321
2 | 384 | 313
3 | 426 | 281
4 | 367 | 281
5 | 390 | 319
6 | 429 | 301
7 | 397 | 316
8 | 397 | 305
9 | 344 | 284
10 | 329 | 326
**Average** | 386.1 | 304.7
**Percentage** | 100% | 78.92 %

21.08% performance gain on 4 logical cores CPU.




