### PR TITLE
In case if no plugins cross-thread error will pop-up.

### DIFF
--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -209,14 +209,21 @@ namespace XrmToolBox
         {
             if (pManager.Plugins.Count == 0)
             {
-                pnlHelp.Visible = true;
+                this.Invoke(new Action(() =>
+                    {
+                        this.pnlHelp.Visible = true;
+                    }));
+                
                 return;
             }
             
             var top = 4;
             int lastWidth = HomePageTab.Width - 28;
 
-            HomePageTab.Controls.Clear();
+            this.Invoke(new Action(() =>
+                {
+                    this.HomePageTab.Controls.Clear();
+                }));
 
             if (currentOptions.DisplayMostUsedFirst)
             {


### PR DESCRIPTION
I have found several places, where cross-thread error might pop-up.
* In case if was no plugins were found in `XrmToolBox` folder;
* In case list of controls on main panel is not empty at the moment of application start (I don't know how this might happen?, but still)