### PR TITLE
Clearing list of already loaded assemblies

### DIFF
--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
@@ -58,6 +58,8 @@ namespace MsCrmTools.AssemblyRecoveryTool
                 },
                 e =>
                 {
+                    listView_Assemblies.Items.Clear();
+
                     var list = (List<Entity>) e.Result;
 
                     foreach (Entity pAssembly in list)


### PR DESCRIPTION
If `Load assemblies` button is pressed more than once in `AssemblyRecoveryTool`, list of assemblies is not cleared. Duplicate entries added instead.