### PR TITLE
Don't use Gembox in 'Easy Translator'

### DIFF
--- a/Plugins/DamSim.SolutionTransferTool/Properties/AssemblyInfo.cs
+++ b/Plugins/DamSim.SolutionTransferTool/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using XrmToolBox.Attributes;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]
 

--- a/Plugins/DamSim.ViewTransferTool/Properties/AssemblyInfo.cs
+++ b/Plugins/DamSim.ViewTransferTool/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/Javista.XrmToolBox.ImportNN/Properties/AssemblyInfo.cs
+++ b/Plugins/Javista.XrmToolBox.ImportNN/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.AccessChecker/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.AccessChecker/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")] 
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.AttributeBulkUpdater/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.AttributeBulkUpdater/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.AuditCenter/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.AuditCenter/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.FetchXmlTester/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.FetchXmlTester/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.FlsBulkUpdater/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.FlsBulkUpdater/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.2.19")]
-[assembly: AssemblyFileVersion("1.2015.2.19")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.FormAttributeManager/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.FormAttributeManager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.FormLibrariesManager/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.FormLibrariesManager/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.FormParameterManager/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.FormParameterManager/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.Iconator/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.Iconator/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.MetadataBrowser/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.MetadataBrowser/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.MetadataDocumentGenerator/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.MetadataDocumentGenerator/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")] 
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")] 

--- a/Plugins/MsCrmTools.PrivDiscover/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.PrivDiscover/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.RoleUpdater/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.RoleUpdater/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.ScriptsFinder/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.ScriptsFinder/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.2.4")]
-[assembly: AssemblyFileVersion("1.2015.2.4")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.SiteMapEditor/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.SiteMapEditor/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.2.4")]
-[assembly: AssemblyFileVersion("1.2015.2.4")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.SolutionComponentsMover/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.SolutionComponentsMover/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.SolutionImport/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.SolutionImport/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.SynchronousEventOrderEditor/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.SynchronousEventOrderEditor/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.Translator/AppCode/AttributeTranslation.cs
+++ b/Plugins/MsCrmTools.Translator/AppCode/AttributeTranslation.cs
@@ -2,11 +2,16 @@
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using GemBox.Spreadsheet;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using System;
+
+#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
 
 namespace MsCrmTools.Translator.AppCode
 {
@@ -48,12 +53,12 @@ namespace MsCrmTools.Translator.AppCode
                     if (attribute.DisplayName != null && attribute.DisplayName.LocalizedLabels.All(l => string.IsNullOrEmpty(l.Label)))
                         continue;
 
-                    sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = attribute.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
 
                     // DisplayName
-                    sheet.Cells[line, cell++].Value = "DisplayName";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "DisplayName";
 
                     foreach (var lcid in languages)
                     {
@@ -68,16 +73,16 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = displayName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = displayName;
                     }
                     
                     // Description
                     line++;
                     cell = 0;
-                    sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                    sheet.Cells[line, cell++].Value = "Description";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                     foreach (var lcid in languages)
                     {
@@ -92,7 +97,7 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = description;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = description;
                     }
 
                     line++;
@@ -102,24 +107,91 @@ namespace MsCrmTools.Translator.AppCode
             // Applying style to cells
             for (int i = 0; i < (4 + languages.Count); i++)
             {
-                sheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                sheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(sheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 4; j++)
                 {
-                    sheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(sheet, i, j).Style);
                 }
             }
         }
 
+#if NO_GEMBOX
         public void Import(ExcelWorksheet sheet, List<EntityMetadata> emds, IOrganizationService service)
         {
             var amds = new List<MasterAttribute>();
 
-            foreach (ExcelRow row in sheet.Rows.Where(r => r.Index != 0).OrderBy(r => r.Index))
+            var rowsCount = sheet.Dimension.Rows;
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                var amd = amds.FirstOrDefault(a => a.Amd.MetadataId == new Guid(ZeroBasedSheet.Cell(sheet, rowI, 0).Value.ToString()));
+                if (amd == null)
+                {
+                    var currentEntity = emds.FirstOrDefault(e => e.LogicalName == ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString());
+                    if (currentEntity == null)
+                    {
+                        var request = new RetrieveEntityRequest
+                        {
+                            LogicalName = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString(),
+                            EntityFilters = EntityFilters.Entity | EntityFilters.Attributes
+                        };
+
+                        var response = ((RetrieveEntityResponse)service.Execute(request));
+                        currentEntity = response.EntityMetadata;
+
+                        emds.Add(currentEntity);
+                    }
+
+                    amd = new MasterAttribute();
+                    amd.Amd = currentEntity.Attributes.FirstOrDefault(a => a.LogicalName == ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString());
+                    amds.Add(amd);
+                }
+
+                int columnIndex = 4;
+
+                if (ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString() == "DisplayName")
+                {
+                    amd.Amd.DisplayName = new Label();
+
+                    while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                    {
+                        amd.Amd.DisplayName.LocalizedLabels.Add(new LocalizedLabel(ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString(), int.Parse(ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString())));
+
+                        columnIndex++;
+                    }
+                }
+                else if (ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString() == "Description")
+                {
+                    amd.Amd.Description = new Label();
+
+                    while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                    {
+                        amd.Amd.Description.LocalizedLabels.Add(new LocalizedLabel(ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString(), int.Parse(ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString())));
+
+                        columnIndex++;
+                    }
+                }
+            }
+
+            foreach (var amd in amds)
+            {
+                if (amd.Amd.DisplayName.LocalizedLabels.All(l => string.IsNullOrEmpty(l.Label))
+                    || amd.Amd.IsRenameable.Value == false)
+                    continue;
+
+                var request = new UpdateAttributeRequest { Attribute = amd.Amd, EntityName = amd.Amd.EntityLogicalName };
+                service.Execute(request);
+            }
+        }
+#else
+        public void Import(ExcelWorksheet sheet, List<EntityMetadata> emds, IOrganizationService service)
+        {
+            var amds = new List<MasterAttribute>();
+
+            foreach (var row in sheet.Rows.Where(r => r.Index != 0).OrderBy(r => r.Index))
             {
                 var amd = amds.FirstOrDefault(a => a.Amd.MetadataId == new Guid(row.Cells[0].Value.ToString()));
                 if (amd == null)
@@ -180,19 +252,20 @@ namespace MsCrmTools.Translator.AppCode
                 service.Execute(request);
             }
         }
+#endif
 
         private void AddHeader(ExcelWorksheet sheet, IEnumerable<int> languages)
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Attribute Id";
-            sheet.Cells[0, cell++].Value = "Entity Logical Name";
-            sheet.Cells[0, cell++].Value = "Attribute Logical Name";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Entity Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/Plugins/MsCrmTools.Translator/AppCode/BooleanTranslation.cs
+++ b/Plugins/MsCrmTools.Translator/AppCode/BooleanTranslation.cs
@@ -3,10 +3,15 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using GemBox.Spreadsheet;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
+
+#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
 
 namespace MsCrmTools.Translator.AppCode
 {
@@ -43,11 +48,11 @@ namespace MsCrmTools.Translator.AppCode
                     if (bAmd.OptionSet.IsGlobal.Value)
                         continue;
 
-                    sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                    sheet.Cells[line, cell++].Value = bAmd.OptionSet.FalseOption.Value;
-                    sheet.Cells[line, cell++].Value = "Label";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bAmd.OptionSet.FalseOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Label";
 
                     foreach (var lcid in languages)
                     {
@@ -63,17 +68,17 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
                     cell = 0;
 
-                    sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                    sheet.Cells[line, cell++].Value = bAmd.OptionSet.FalseOption.Value;
-                    sheet.Cells[line, cell++].Value = "Description";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bAmd.OptionSet.FalseOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                     foreach (var lcid in languages)
                     {
@@ -89,17 +94,17 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
                     cell = 0;
 
-                    sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                    sheet.Cells[line, cell++].Value = bAmd.OptionSet.TrueOption.Value;
-                    sheet.Cells[line, cell++].Value = "Label";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bAmd.OptionSet.TrueOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Label";
 
                     foreach (var lcid in languages)
                     {
@@ -115,17 +120,17 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
                     cell = 0;
 
-                    sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                    sheet.Cells[line, cell++].Value = bAmd.OptionSet.TrueOption.Value;
-                    sheet.Cells[line, cell++].Value = "Description";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bAmd.OptionSet.TrueOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                     foreach (var lcid in languages)
                     {
@@ -141,7 +146,7 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
@@ -151,19 +156,118 @@ namespace MsCrmTools.Translator.AppCode
             // Applying style to cells
             for (int i = 0; i < (5 + languages.Count); i++)
             {
-                sheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                sheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(sheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 5; j++)
                 {
-                    sheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(sheet, i, j).Style);
                 }
             }
         }
 
+#if NO_GEMBOX
+        public void Import(ExcelWorksheet sheet, IOrganizationService service)
+        {
+            var requests = new List<UpdateOptionValueRequest>();
+
+            var rowsCount = sheet.Dimension.Rows;
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                UpdateOptionValueRequest request = requests.FirstOrDefault(r => r.OptionSetName == ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString());
+                if (request == null)
+                {
+                    request = new UpdateOptionValueRequest
+                    {
+                        AttributeLogicalName = ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString(),
+                        EntityLogicalName = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString(),
+                        Value = int.Parse(ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString()),
+                        Label = new Label(),
+                        Description = new Label(),
+                        MergeLabels = true
+                    };
+
+                    int columnIndex = 5;
+
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 4).Value.ToString() == "Label")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Label.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 4).Value.ToString() == "Description")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Description.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+
+                    requests.Add(request);
+                }
+                else
+                {
+                    int columnIndex = 5;
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 4).Value.ToString() == "Label")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Label.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 4).Value.ToString() == "Description")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Description.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                }
+            }
+
+            foreach (var request in requests)
+            {
+                service.Execute(request);
+            }
+        }
+#else
         public void Import(ExcelWorksheet sheet, IOrganizationService service)
         {
             var requests = new List<UpdateOptionValueRequest>();
@@ -190,7 +294,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -204,7 +308,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -225,7 +329,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -239,7 +343,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -257,20 +361,21 @@ namespace MsCrmTools.Translator.AppCode
                 service.Execute(request);
             }
         }
+#endif
 
         private void AddHeader(ExcelWorksheet sheet, IEnumerable<int> languages)
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Attribute Id";
-            sheet.Cells[0, cell++].Value = "Entity Logical Name";
-            sheet.Cells[0, cell++].Value = "Attribute Logical Name";
-            sheet.Cells[0, cell++].Value = "Value";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Entity Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Value";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/Plugins/MsCrmTools.Translator/AppCode/EntityTranslation.cs
+++ b/Plugins/MsCrmTools.Translator/AppCode/EntityTranslation.cs
@@ -1,12 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using GemBox.Spreadsheet;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
+
+#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
 
 namespace MsCrmTools.Translator.AppCode
 {
@@ -35,11 +39,11 @@ namespace MsCrmTools.Translator.AppCode
 
                     var cell = 0;
 
-                    sheet.Cells[line, cell++].Value = entity.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
+                   ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.MetadataId.Value.ToString("B");
+                   ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
 
                     // DisplayName
-                    sheet.Cells[line, cell++].Value = "DisplayName";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "DisplayName";
 
                     foreach (var lcid in languages)
                     {
@@ -54,15 +58,15 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = displayName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = displayName;
                     }
 
                     // Plural Name
                     line++;
                     cell = 0;
-                    sheet.Cells[line, cell++].Value = entity.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = "DisplayCollectionName";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "DisplayCollectionName";
 
                     foreach (var lcid in languages)
                     {
@@ -77,15 +81,15 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = collectionName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = collectionName;
                     }
                     
                     // Description
                     line++;
                     cell = 0;
-                    sheet.Cells[line, cell++].Value = entity.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = entity.LogicalName;
-                    sheet.Cells[line, cell++].Value = "Description";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                     foreach (var lcid in languages)
                     {
@@ -100,7 +104,7 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = description;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = description;
                     }
 
                     line++;
@@ -109,19 +113,93 @@ namespace MsCrmTools.Translator.AppCode
             // Applying style to cells
             for (int i = 0; i < (3 + languages.Count); i++)
             {
-                sheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                sheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(sheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 3; j++)
                 {
-                    sheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(sheet, i, j).Style);
                 }
             }
         }
 
+#if NO_GEMBOX
+        public void Import(ExcelWorksheet sheet, List<EntityMetadata> emds, IOrganizationService service)
+        {
+            var rowsCount = sheet.Dimension.Rows;
+
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                {
+                    var emd = emds.FirstOrDefault(e => e.LogicalName == ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString());
+                    if (emd == null)
+                    {
+                        var request = new RetrieveEntityRequest
+                        {
+                            LogicalName = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString(),
+                            EntityFilters = EntityFilters.Entity | EntityFilters.Attributes
+                        };
+
+                        var response = ((RetrieveEntityResponse) service.Execute(request));
+                        emd = response.EntityMetadata;
+
+                        emds.Add(emd);
+                    }
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString() == "DisplayName")
+                    {
+                        emd.DisplayName = new Label();
+                        int columnIndex = 3;
+
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            emd.DisplayName.LocalizedLabels.Add(
+                                new LocalizedLabel(ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString(),
+                                    int.Parse(ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString())));
+
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString() == "DisplayCollectionName")
+                    {
+                        emd.DisplayCollectionName = new Label();
+                        int columnIndex = 3;
+
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            emd.DisplayCollectionName.LocalizedLabels.Add(
+                                new LocalizedLabel(ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString(),
+                                    int.Parse(ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString())));
+
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString() == "Description")
+                    {
+                        emd.Description = new Label();
+                        int columnIndex = 3;
+
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            emd.Description.LocalizedLabels.Add(
+                                new LocalizedLabel(ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString(),
+                                    int.Parse(ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString())));
+
+                            columnIndex++;
+                        }
+                    }
+                }
+
+                foreach (var emd in emds.Where(e => e.IsRenameable.Value))
+                {
+                    var request = new UpdateEntityRequest {Entity = emd};
+                    service.Execute(request);
+                }
+            }
+        }
+#else
         public void Import(ExcelWorksheet sheet, List<EntityMetadata> emds, IOrganizationService service)
         {
             foreach (ExcelRow row in sheet.Rows.Where(r => r.Index != 0).OrderBy(r => r.Index))
@@ -185,18 +263,18 @@ namespace MsCrmTools.Translator.AppCode
                 service.Execute(request);
             }
         }
-
+#endif
         private void AddHeader(ExcelWorksheet sheet, IEnumerable<int> languages)
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Entity Id";
-            sheet.Cells[0, cell++].Value = "Entity Logical Name";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Entity Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Entity Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/Plugins/MsCrmTools.Translator/AppCode/GlobalOptionSetTranslation.cs
+++ b/Plugins/MsCrmTools.Translator/AppCode/GlobalOptionSetTranslation.cs
@@ -1,12 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
-using GemBox.Spreadsheet;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
+
+#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
 
 namespace MsCrmTools.Translator.AppCode
 {
@@ -38,10 +42,10 @@ namespace MsCrmTools.Translator.AppCode
                     foreach (var option in oomd.Options.OrderBy(o => o.Value))
                     {
                         var cell = 0;
-                        sheet.Cells[line, cell++].Value = omd.MetadataId.Value.ToString("B");
-                        sheet.Cells[line, cell++].Value = omd.Name;
-                        sheet.Cells[line, cell++].Value = option.Value;
-                        sheet.Cells[line, cell++].Value = "Label";
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.MetadataId.Value.ToString("B");
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.Name;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = option.Value;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Label";
 
                         foreach (var lcid in languages)
                         {
@@ -53,15 +57,15 @@ namespace MsCrmTools.Translator.AppCode
                                 label = optionLabel.Label;
                             }
 
-                            sheet.Cells[line, cell++].Value = label;
+                            ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                         }
 
                         line++;
                         cell = 0;
-                        sheet.Cells[line, cell++].Value = omd.MetadataId.Value.ToString("B");
-                        sheet.Cells[line, cell++].Value = omd.Name;
-                        sheet.Cells[line, cell++].Value = option.Value;
-                        sheet.Cells[line, cell++].Value = "Description";
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.MetadataId.Value.ToString("B");
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.Name;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = option.Value;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                         foreach (var lcid in languages)
                         {
@@ -73,7 +77,7 @@ namespace MsCrmTools.Translator.AppCode
                                 label = optionDescription.Label;
                             }
 
-                            sheet.Cells[line, cell++].Value = label;
+                            ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                         }
 
                         line++;
@@ -84,10 +88,10 @@ namespace MsCrmTools.Translator.AppCode
                     var bomd = (BooleanOptionSetMetadata)omd;
 
                     var cell = 0;
-                    sheet.Cells[line, cell++].Value = omd.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = omd.Name;
-                    sheet.Cells[line, cell++].Value = bomd.FalseOption.Value;
-                    sheet.Cells[line, cell++].Value = "Label";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.Name;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bomd.FalseOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Label";
 
                     foreach (var lcid in languages)
                     {
@@ -103,16 +107,16 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
                     cell = 0;
 
-                    sheet.Cells[line, cell++].Value = omd.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = omd.Name;
-                    sheet.Cells[line, cell++].Value = bomd.FalseOption.Value;
-                    sheet.Cells[line, cell++].Value = "Description";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.Name;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bomd.FalseOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                     foreach (var lcid in languages)
                     {
@@ -128,16 +132,16 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
                     cell = 0;
 
-                    sheet.Cells[line, cell++].Value = omd.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = omd.Name;
-                    sheet.Cells[line, cell++].Value = bomd.TrueOption.Value;
-                    sheet.Cells[line, cell++].Value = "Label";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.Name;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bomd.TrueOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Label";
 
                     foreach (var lcid in languages)
                     {
@@ -153,16 +157,16 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
                     cell = 0;
 
-                    sheet.Cells[line, cell++].Value = omd.MetadataId.Value.ToString("B");
-                    sheet.Cells[line, cell++].Value = omd.Name;
-                    sheet.Cells[line, cell++].Value = bomd.TrueOption.Value;
-                    sheet.Cells[line, cell++].Value = "Description";
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.MetadataId.Value.ToString("B");
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = omd.Name;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = bomd.TrueOption.Value;
+                    ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                     foreach (var lcid in languages)
                     {
@@ -178,7 +182,7 @@ namespace MsCrmTools.Translator.AppCode
                             }
                         }
 
-                        sheet.Cells[line, cell++].Value = label;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                     }
 
                     line++;
@@ -188,19 +192,120 @@ namespace MsCrmTools.Translator.AppCode
             // Applying style to cells
             for (int i = 0; i < (4 + languages.Count); i++)
             {
-                sheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                sheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(sheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 4; j++)
                 {
-                    sheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(sheet, i, j).Style);
                 }
             }
         }
 
+#if NO_GEMBOX
+        public void Import(ExcelWorksheet sheet, IOrganizationService service)
+        {
+            var requests = new List<UpdateOptionValueRequest>();
+
+            var rowsCount = sheet.Dimension.Rows;
+
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                UpdateOptionValueRequest request = requests.FirstOrDefault(r => r.OptionSetName == ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString()
+                    && r.Value == int.Parse(ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString()));
+                if (request == null)
+                {
+                    request = new UpdateOptionValueRequest
+                    {
+                        OptionSetName = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString(),
+                        Value = int.Parse(ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString()),
+                        Label = new Label(),
+                        Description = new Label(),
+                        MergeLabels = true
+                    };
+
+                    int columnIndex = 4;
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString() == "Label")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Label.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString() == "Description")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Description.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+
+                            columnIndex++;
+                        }
+                    }
+
+                    requests.Add(request);
+                }
+                else
+                {
+                    int columnIndex = 4;
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString() == "Label")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Label.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 3).Value.ToString() == "Description")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Description.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                }
+            }
+
+            foreach (var request in requests)
+            {
+                service.Execute(request);
+            }
+        }
+#else
         public void Import(ExcelWorksheet sheet, IOrganizationService service)
         {
             var requests = new List<UpdateOptionValueRequest>();
@@ -226,7 +331,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -241,7 +346,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -263,7 +368,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -277,7 +382,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -295,19 +400,19 @@ namespace MsCrmTools.Translator.AppCode
                 service.Execute(request);
             }
         }
-
+#endif
         private void AddHeader(ExcelWorksheet sheet, IEnumerable<int> languages)
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "OptionSet Id";
-            sheet.Cells[0, cell++].Value = "OptionSet Name";
-            sheet.Cells[0, cell++].Value = "Value";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "OptionSet Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "OptionSet Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Value";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/Plugins/MsCrmTools.Translator/AppCode/OptionSetTranslation.cs
+++ b/Plugins/MsCrmTools.Translator/AppCode/OptionSetTranslation.cs
@@ -4,11 +4,16 @@ using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
-using GemBox.Spreadsheet;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Metadata;
 using Label = Microsoft.Xrm.Sdk.Label;
+
+#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
 
 namespace MsCrmTools.Translator.AppCode
 {
@@ -62,12 +67,12 @@ namespace MsCrmTools.Translator.AppCode
                    
                     foreach (var option in omd.Options.OrderBy(o => o.Value))
                     {
-                        sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                        sheet.Cells[line, cell++].Value = entity.LogicalName;
-                        sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                        sheet.Cells[line, cell++].Value = attribute.AttributeType.Value.ToString();
-                        sheet.Cells[line, cell++].Value = option.Value;
-                        sheet.Cells[line, cell++].Value = "Label";
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.AttributeType.Value.ToString();
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = option.Value;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Label";
 
                         foreach (var lcid in languages)
                         {
@@ -82,18 +87,18 @@ namespace MsCrmTools.Translator.AppCode
                                 }
                             }
 
-                            sheet.Cells[line, cell++].Value = label;
+                            ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                         }
 
                         line++;
                         cell = 0;
 
-                        sheet.Cells[line, cell++].Value = attribute.MetadataId.Value.ToString("B");
-                        sheet.Cells[line, cell++].Value = entity.LogicalName;
-                        sheet.Cells[line, cell++].Value = attribute.LogicalName;
-                        sheet.Cells[line, cell++].Value = attribute.AttributeType.Value.ToString();
-                        sheet.Cells[line, cell++].Value = option.Value;
-                        sheet.Cells[line, cell++].Value = "Description";
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.MetadataId.Value.ToString("B");
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = entity.LogicalName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.LogicalName;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = attribute.AttributeType.Value.ToString();
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = option.Value;
+                        ZeroBasedSheet.Cell(sheet, line, cell++).Value = "Description";
 
                         foreach (var lcid in languages)
                         {
@@ -108,7 +113,7 @@ namespace MsCrmTools.Translator.AppCode
                                 }
                             }
 
-                            sheet.Cells[line, cell++].Value = label;
+                            ZeroBasedSheet.Cell(sheet, line, cell++).Value = label;
                         }
 
                         line++;
@@ -120,19 +125,123 @@ namespace MsCrmTools.Translator.AppCode
             // Applying style to cells
             for (int i = 0; i < (6 + languages.Count); i++)
             {
-                sheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                sheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(sheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 6; j++)
                 {
-                    sheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(sheet, 0, i).Style);
                 }
             }
         }
 
+#if NO_GEMBOX
+        public void Import(ExcelWorksheet sheet, IOrganizationService service)
+        {
+            var requests = new List<UpdateOptionValueRequest>();
+
+            var rowsCount = sheet.Dimension.Rows;
+
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                UpdateOptionValueRequest request =
+                    requests
+                    .FirstOrDefault(
+                        r => r.OptionSetName == ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString() &&
+                        r.Value == int.Parse(ZeroBasedSheet.Cell(sheet, rowI, 4).Value.ToString()));
+
+                if (request == null)
+                {
+                    request = new UpdateOptionValueRequest
+                    {
+                        AttributeLogicalName = ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString(),
+                        EntityLogicalName = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString(),
+                        Value = int.Parse(ZeroBasedSheet.Cell(sheet, rowI, 4).Value.ToString()),
+                        Label = new Label(),
+                        Description = new Label(),
+                        MergeLabels = true
+                    };
+
+                    int columnIndex = 6;
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 5).Value.ToString() == "Label")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Label.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 5).Value.ToString() == "Description")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Description.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+
+                    requests.Add(request);
+                }
+                else
+                {
+                    int columnIndex = 6;
+
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 5).Value.ToString() == "Label")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Label.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                    else if (ZeroBasedSheet.Cell(sheet, rowI, 5).Value.ToString() == "Description")
+                    {
+                        // WTF: QUESTIONABLE DELETION: row.Cells.Count() > columnIndex && 
+                        while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex) != null && ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                        {
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
+                            var sLabel = ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString();
+
+                            if (sLcid.Length > 0 && sLabel.Length > 0)
+                            {
+                                request.Description.LocalizedLabels.Add(new LocalizedLabel(sLabel, int.Parse(sLcid)));
+                            }
+                            columnIndex++;
+                        }
+                    }
+                }
+            }
+
+            foreach (var request in requests)
+            {
+                service.Execute(request);
+            }
+        }
+#else
         public void Import(ExcelWorksheet sheet, IOrganizationService service)
         {
             var requests = new List<UpdateOptionValueRequest>();
@@ -158,7 +267,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -172,7 +281,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -193,7 +302,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -207,7 +316,7 @@ namespace MsCrmTools.Translator.AppCode
                     {
                         while (row.Cells.Count() > columnIndex && row.Cells[columnIndex] != null && row.Cells[columnIndex].Value != null)
                         {
-                            var sLcid = sheet.Cells[0, columnIndex].Value.ToString();
+                            var sLcid = ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString();
                             var sLabel = row.Cells[columnIndex].Value.ToString();
 
                             if (sLcid.Length > 0 && sLabel.Length > 0)
@@ -225,21 +334,21 @@ namespace MsCrmTools.Translator.AppCode
                 service.Execute(request);
             }
         }
-
+#endif
         private void AddHeader(ExcelWorksheet sheet, IEnumerable<int> languages)
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Attribute Id";
-            sheet.Cells[0, cell++].Value = "Entity Logical Name";
-            sheet.Cells[0, cell++].Value = "Attribute Logical Name";
-            sheet.Cells[0, cell++].Value = "Attribute Type";
-            sheet.Cells[0, cell++].Value = "Value";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Entity Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Logical Name";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Attribute Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Value";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
     }

--- a/Plugins/MsCrmTools.Translator/AppCode/SiteMapTranslation.cs
+++ b/Plugins/MsCrmTools.Translator/AppCode/SiteMapTranslation.cs
@@ -5,11 +5,16 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Policy;
 using System.Xml;
-using GemBox.Spreadsheet;
 using Microsoft.Crm.Sdk;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
+
+#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
 
 namespace MsCrmTools.Translator.AppCode
 {
@@ -24,9 +29,13 @@ namespace MsCrmTools.Translator.AppCode
         /// viewId;entityLogicalName;viewName;ViewType;Type;LCID1;LCID2;...;LCODX
         /// </example>
         /// <param name="languages"></param>
-        /// <param name="sheet"></param>
+        /// <param name="file"></param>
         /// <param name="service"></param>
+#if NO_GEMBOX
+        public void Export(List<int> languages, ExcelWorkbook file, IOrganizationService service)
+#else
         public void Export(List<int> languages, ExcelFile file, IOrganizationService service)
+#endif
         {
             var line = 1;
 
@@ -114,22 +123,22 @@ namespace MsCrmTools.Translator.AppCode
             foreach (var crmArea in crmSiteMapAreas)
             {
                 var cell = 0;
-                areaSheet.Cells[line, cell++].Value = crmArea.Id;
-                areaSheet.Cells[line, cell++].Value = "Title";
+                ZeroBasedSheet.Cell(areaSheet, line, cell++).Value = crmArea.Id;
+                ZeroBasedSheet.Cell(areaSheet, line, cell++).Value = "Title";
 
                 foreach (var lcid in languages)
                 {
-                    areaSheet.Cells[line, cell++].Value = crmArea.Titles.FirstOrDefault(n => n.Key == lcid).Value;
+                    ZeroBasedSheet.Cell(areaSheet, line, cell++).Value = crmArea.Titles.FirstOrDefault(n => n.Key == lcid).Value;
                 }
 
                 line++;
                 cell = 0;
-                areaSheet.Cells[line, cell++].Value = crmArea.Id;
-                areaSheet.Cells[line, cell++].Value = "Description";
+                ZeroBasedSheet.Cell(areaSheet, line, cell++).Value = crmArea.Id;
+                ZeroBasedSheet.Cell(areaSheet, line, cell++).Value = "Description";
 
                 foreach (var lcid in languages)
                 {
-                    areaSheet.Cells[line, cell++].Value = crmArea.Descriptions.FirstOrDefault(n => n.Key == lcid).Value;
+                    ZeroBasedSheet.Cell(areaSheet, line, cell++).Value = crmArea.Descriptions.FirstOrDefault(n => n.Key == lcid).Value;
                 }
                 line++;
             }
@@ -144,24 +153,24 @@ namespace MsCrmTools.Translator.AppCode
             foreach (var crmGroup in crmSiteMapGroups)
             {
                 var cell = 0;
-                groupSheet.Cells[line, cell++].Value = crmGroup.AreaId;
-                groupSheet.Cells[line, cell++].Value = crmGroup.Id;
-                groupSheet.Cells[line, cell++].Value = "Title";
+                ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = crmGroup.AreaId;
+                ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = crmGroup.Id;
+                ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = "Title";
 
                 foreach (var lcid in languages)
                 {
-                    groupSheet.Cells[line, cell++].Value = crmGroup.Titles.FirstOrDefault(n => n.Key == lcid).Value;
+                    ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = crmGroup.Titles.FirstOrDefault(n => n.Key == lcid).Value;
                 }
 
                 line++;
                 cell = 0;
-                groupSheet.Cells[line, cell++].Value = crmGroup.AreaId;
-                groupSheet.Cells[line, cell++].Value = crmGroup.Id;
-                groupSheet.Cells[line, cell++].Value = "Description";
+                ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = crmGroup.AreaId;
+                ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = crmGroup.Id;
+                ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = "Description";
 
                 foreach (var lcid in languages)
                 {
-                    groupSheet.Cells[line, cell++].Value = crmGroup.Descriptions.FirstOrDefault(n => n.Key == lcid).Value;
+                    ZeroBasedSheet.Cell(groupSheet, line, cell++).Value = crmGroup.Descriptions.FirstOrDefault(n => n.Key == lcid).Value;
                 }
                 line++;
             }
@@ -176,26 +185,26 @@ namespace MsCrmTools.Translator.AppCode
             foreach (var crmSubArea in crmSiteMapSubAreas)
             {
                 var cell = 0;
-                subAreaSheet.Cells[line, cell++].Value = crmSubArea.AreaId;
-                subAreaSheet.Cells[line, cell++].Value = crmSubArea.GroupId;
-                subAreaSheet.Cells[line, cell++].Value = crmSubArea.Id;
-                subAreaSheet.Cells[line, cell++].Value = "Title";
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.AreaId;
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.GroupId;
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.Id;
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = "Title";
 
                 foreach (var lcid in languages)
                 {
-                    subAreaSheet.Cells[line, cell++].Value = crmSubArea.Titles.FirstOrDefault(n => n.Key == lcid).Value;
+                    ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.Titles.FirstOrDefault(n => n.Key == lcid).Value;
                 }
 
                 line++;
                 cell = 0;
-                subAreaSheet.Cells[line, cell++].Value = crmSubArea.AreaId;
-                subAreaSheet.Cells[line, cell++].Value = crmSubArea.GroupId;
-                subAreaSheet.Cells[line, cell++].Value = crmSubArea.Id;
-                subAreaSheet.Cells[line, cell++].Value = "Description";
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.AreaId;
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.GroupId;
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.Id;
+                ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = "Description";
 
                 foreach (var lcid in languages)
                 {
-                    subAreaSheet.Cells[line, cell++].Value = crmSubArea.Descriptions.FirstOrDefault(n => n.Key == lcid).Value;
+                    ZeroBasedSheet.Cell(subAreaSheet, line, cell++).Value = crmSubArea.Descriptions.FirstOrDefault(n => n.Key == lcid).Value;
                 }
                 line++;
             }
@@ -205,42 +214,40 @@ namespace MsCrmTools.Translator.AppCode
             // Applying style to cells
             for (int i = 0; i < (2 + languages.Count); i++)
             {
-                areaSheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                areaSheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(areaSheet, 0, i).Style);
             }
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 2; j++)
                 {
-                    areaSheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(areaSheet, i, j).Style);
                 }
             }
 
             for (int i = 0; i < (3 + languages.Count); i++)
             {
-                groupSheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                groupSheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(groupSheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 3; j++)
                 {
-                    groupSheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(groupSheet, i, j).Style);
+
                 }
             }
 
             for (int i = 0; i < (4 + languages.Count); i++)
             {
-                subAreaSheet.Cells[0, i].Style.FillPattern.SetSolid(Color.PowderBlue);
-                subAreaSheet.Cells[0, i].Style.Font.Weight = ExcelFont.BoldWeight;
+                StyleMutator.TitleCell(ZeroBasedSheet.Cell(subAreaSheet, 0, i).Style);
             }
 
             for (int i = 1; i < line; i++)
             {
                 for (int j = 0; j < 4; j++)
                 {
-                    subAreaSheet.Cells[i, j].Style.FillPattern.SetSolid(Color.AliceBlue);
+                    StyleMutator.HighlightedCell(ZeroBasedSheet.Cell(subAreaSheet, i, j).Style);
                 }
             }
         }
@@ -253,6 +260,141 @@ namespace MsCrmTools.Translator.AppCode
             return siteMap;
         }
 
+#if NO_GEMBOX
+        public void PrepareAreas(ExcelWorksheet sheet, IOrganizationService service)
+        {
+            if (siteMap == null)
+            {
+                siteMap = GetSiteMap(service);
+            }
+
+            var siteMapDoc = new XmlDocument();
+            siteMapDoc.LoadXml(siteMap["sitemapxml"].ToString());
+
+            var rowsCount = sheet.Dimension.Rows;
+
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                if (ZeroBasedSheet.Cell(sheet, rowI, 0).Value == null) break;
+
+                var areaId = ZeroBasedSheet.Cell(sheet, rowI, 0).Value.ToString();
+                var areaNode = siteMapDoc.SelectSingleNode("SiteMap/Area[@Id='" + areaId + "']");
+                if (areaNode == null)
+                {
+                    throw new Exception("Unable to find area with id " + areaId);
+                }
+
+                var columnIndex = 2;
+                while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                {
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString() == "Title")
+                    {
+                        UpdateXmlNode(areaNode, "Titles", "Title", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
+                            ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString());
+                    }
+                    else
+                    {
+                        UpdateXmlNode(areaNode, "Descriptions", "Description", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
+                         ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString());
+                    }
+                    columnIndex++;
+                }
+
+            }
+
+            siteMap["sitemapxml"] = siteMapDoc.OuterXml;
+        }
+
+        public void PrepareGroups(ExcelWorksheet sheet, IOrganizationService service)
+        {
+            if (siteMap == null)
+            {
+                siteMap = GetSiteMap(service);
+            }
+
+            var siteMapDoc = new XmlDocument();
+            siteMapDoc.LoadXml(siteMap["sitemapxml"].ToString());
+
+            var rowsCount = sheet.Dimension.Rows;
+
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                if (ZeroBasedSheet.Cell(sheet, rowI, 0).Value == null) break;
+
+                var areaId = ZeroBasedSheet.Cell(sheet, rowI, 0).Value.ToString();
+                var groupId = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString();
+                var groupNode = siteMapDoc.SelectSingleNode("SiteMap/Area[@Id='" + areaId + "']/Group[@Id='" + groupId + "']");
+                if (groupNode == null)
+                {
+                    throw new Exception("Unable to find group with id " + groupId + " in area " + areaId);
+                }
+
+                var columnIndex = 3;
+                while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                {
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString() == "Title")
+                    {
+                        UpdateXmlNode(groupNode, "Titles", "Title", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
+                            ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString());
+                    }
+                    else
+                    {
+                        UpdateXmlNode(groupNode, "Descriptions", "Description", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
+                         ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString());
+                    }
+                    columnIndex++;
+                }
+
+            }
+
+            siteMap["sitemapxml"] = siteMapDoc.OuterXml;
+        }
+
+        public void PrepareSubAreas(ExcelWorksheet sheet, IOrganizationService service)
+        {
+            if (siteMap == null)
+            {
+                siteMap = GetSiteMap(service);
+            }
+
+            var siteMapDoc = new XmlDocument();
+            siteMapDoc.LoadXml(siteMap["sitemapxml"].ToString());
+
+            var rowsCount = sheet.Dimension.Rows;
+
+            for (var rowI = 1; rowI < rowsCount; rowI++)
+            {
+                if (ZeroBasedSheet.Cell(sheet, rowI, 0).Value == null) break;
+
+                var areaId = ZeroBasedSheet.Cell(sheet, rowI, 0).Value.ToString();
+                var groupId = ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString();
+                var subAreaId = ZeroBasedSheet.Cell(sheet, rowI, 2).Value.ToString();
+                var subAreaNode = siteMapDoc.SelectSingleNode("SiteMap/Area[@Id='" + areaId + "']/Group[@Id='" + groupId + "']/SubArea[@Id='" + subAreaId + "']");
+                if (subAreaNode == null)
+                {
+                    throw new Exception("Unable to find group with id " + groupId + " in area " + areaId);
+                }
+
+                var columnIndex = 4;
+                while (ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value != null)
+                {
+                    if (ZeroBasedSheet.Cell(sheet, rowI, 1).Value.ToString() == "Title")
+                    {
+                        UpdateXmlNode(subAreaNode, "Titles", "Title", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
+                            ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString());
+                    }
+                    else
+                    {
+                        UpdateXmlNode(subAreaNode, "Descriptions", "Description", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
+                         ZeroBasedSheet.Cell(sheet, rowI, columnIndex).Value.ToString());
+                    }
+                    columnIndex++;
+                }
+            }
+
+            siteMap["sitemapxml"] = siteMapDoc.OuterXml;
+        }
+#else
         public void PrepareAreas(ExcelWorksheet sheet, IOrganizationService service)
         {
             if (siteMap == null)
@@ -280,12 +422,12 @@ namespace MsCrmTools.Translator.AppCode
                 {
                     if (row.Cells[1].Value.ToString() == "Title")
                     {
-                        UpdateXmlNode(areaNode, "Titles", "Title", sheet.Cells[0, columnIndex].Value.ToString(),
+                        UpdateXmlNode(areaNode, "Titles", "Title", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
                             row.Cells[columnIndex].Value.ToString());
                     }
                     else
                     {
-                        UpdateXmlNode(areaNode, "Descriptions", "Description", sheet.Cells[0, columnIndex].Value.ToString(),
+                        UpdateXmlNode(areaNode, "Descriptions", "Description", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
                          row.Cells[columnIndex].Value.ToString());
                     }
                     columnIndex++;
@@ -324,12 +466,12 @@ namespace MsCrmTools.Translator.AppCode
                 {
                     if (row.Cells[1].Value.ToString() == "Title")
                     {
-                        UpdateXmlNode(groupNode, "Titles", "Title", sheet.Cells[0, columnIndex].Value.ToString(),
+                        UpdateXmlNode(groupNode, "Titles", "Title", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
                             row.Cells[columnIndex].Value.ToString());
                     }
                     else
                     {
-                        UpdateXmlNode(groupNode, "Descriptions", "Description", sheet.Cells[0, columnIndex].Value.ToString(),
+                        UpdateXmlNode(groupNode, "Descriptions", "Description", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
                          row.Cells[columnIndex].Value.ToString());
                     }
                     columnIndex++;
@@ -369,12 +511,12 @@ namespace MsCrmTools.Translator.AppCode
                 {
                     if (row.Cells[1].Value.ToString() == "Title")
                     {
-                        UpdateXmlNode(subAreaNode, "Titles", "Title", sheet.Cells[0, columnIndex].Value.ToString(),
+                        UpdateXmlNode(subAreaNode, "Titles", "Title", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
                             row.Cells[columnIndex].Value.ToString());
                     }
                     else
                     {
-                        UpdateXmlNode(subAreaNode, "Descriptions", "Description", sheet.Cells[0, columnIndex].Value.ToString(),
+                        UpdateXmlNode(subAreaNode, "Descriptions", "Description", ZeroBasedSheet.Cell(sheet, 0, columnIndex).Value.ToString(),
                          row.Cells[columnIndex].Value.ToString());
                     }
                     columnIndex++;
@@ -383,7 +525,7 @@ namespace MsCrmTools.Translator.AppCode
 
             siteMap["sitemapxml"] = siteMapDoc.OuterXml;
         }
-
+#endif
         public void Import(IOrganizationService service)
         {
            service.Update(siteMap);
@@ -393,12 +535,12 @@ namespace MsCrmTools.Translator.AppCode
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Area Id";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Area Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -406,13 +548,13 @@ namespace MsCrmTools.Translator.AppCode
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Area Id";
-            sheet.Cells[0, cell++].Value = "Group Id";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Area Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Group Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -420,14 +562,14 @@ namespace MsCrmTools.Translator.AppCode
         {
             var cell = 0;
 
-            sheet.Cells[0, cell++].Value = "Area Id";
-            sheet.Cells[0, cell++].Value = "Group Id";
-            sheet.Cells[0, cell++].Value = "SubArea Id";
-            sheet.Cells[0, cell++].Value = "Type";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Area Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Group Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "SubArea Id";
+            ZeroBasedSheet.Cell(sheet, 0, cell++).Value = "Type";
 
             foreach (var lcid in languages)
             {
-                sheet.Cells[0, cell++].Value = lcid.ToString(CultureInfo.InvariantCulture);
+                ZeroBasedSheet.Cell(sheet, 0, cell++).Value = lcid.ToString(CultureInfo.InvariantCulture);
             }
         }
 

--- a/Plugins/MsCrmTools.Translator/MsCrmTools.Translator.csproj
+++ b/Plugins/MsCrmTools.Translator/MsCrmTools.Translator.csproj
@@ -39,7 +39,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Without GemBox|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug Without GemBox\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NO_GEMBOX</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -47,6 +47,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EPPlus">
+      <HintPath>..\..\packages\EPPlus.4.0.3\lib\net20\EPPlus.dll</HintPath>
+    </Reference>
     <Reference Include="GemBox.Document, Version=23.3.30.1104, Culture=neutral, PublicKeyToken=b1b72c69714d4847, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\GemBox.Document.23.3.30.1040\lib\net30\GemBox.Document.dll</HintPath>
@@ -118,6 +121,8 @@
     <Compile Include="MainControl.Designer.cs">
       <DependentUpon>MainControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="StyleMutator.cs" />
+    <Compile Include="ZeroBasedSheet.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/Plugins/MsCrmTools.Translator/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.Translator/Properties/AssemblyInfo.cs
@@ -17,5 +17,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.Translator/StyleMutator.cs
+++ b/Plugins/MsCrmTools.Translator/StyleMutator.cs
@@ -1,0 +1,55 @@
+﻿using System.Drawing;
+
+#if NO_GEMBOX
+using ExcelWorksheet = OfficeOpenXml.ExcelWorksheet;
+using OfficeOpenXml.Style;
+#else
+using GemBox.Spreadsheet;
+using ExcelWorksheet = GemBox.Spreadsheet.ExcelWorksheet;
+#endif
+
+namespace MsCrmTools.Translator
+{
+    public static class StyleMutator
+    {
+        private static readonly Color TitleColor = Color.PowderBlue;
+        private static readonly Color RowColor = Color.AliceBlue;
+
+#if NO_GEMBOX
+        public static void TitleCell(ExcelStyle style)
+        {
+            style.Fill.PatternType = ExcelFillStyle.Solid;
+            style.Fill.BackgroundColor.SetColor(TitleColor);
+            style.Font.Bold = true;
+        }
+
+        public static void HighlightedCell(ExcelStyle style)
+        {
+            style.Fill.PatternType = ExcelFillStyle.Solid;
+            style.Fill.BackgroundColor.SetColor(RowColor);
+        }
+
+        public static void FontDefaults(ExcelWorksheet sheet)
+        {
+            sheet.Cells.Style.Font.Name = "Arial";
+            sheet.Cells.Style.Font.Size = 10;
+        }
+#else
+        public static void TitleCell(CellStyle style)
+        {
+            style.FillPattern.SetSolid(TitleColor);
+            style.Font.Weight = ExcelFont.BoldWeight;  
+        }
+
+        public static void HighlightedCell(CellStyle style)
+        {
+            style.FillPattern.SetSolid(RowColor);
+        }
+
+        public static void FontDefaults(ExcelWorksheet sheet)
+        {
+        }
+#endif
+    }
+}
+

--- a/Plugins/MsCrmTools.Translator/ZeroBasedSheet.cs
+++ b/Plugins/MsCrmTools.Translator/ZeroBasedSheet.cs
@@ -1,0 +1,23 @@
+﻿#if NO_GEMBOX
+using OfficeOpenXml;
+#else
+using GemBox.Spreadsheet;
+#endif
+
+namespace MsCrmTools.Translator
+{
+    public static class ZeroBasedSheet
+    {
+#if NO_GEMBOX
+        public static ExcelRange Cell(ExcelWorksheet sheet, int x, int y)
+        {
+            return sheet.Cells[x + 1, y + 1];
+        }
+#else
+        public static ExcelCell Cell(ExcelWorksheet sheet, int x, int y)
+        {
+            return sheet.Cells[x, y];
+        }
+#endif
+    }
+}

--- a/Plugins/MsCrmTools.Translator/packages.config
+++ b/Plugins/MsCrmTools.Translator/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EPPlus" version="4.0.3" targetFramework="net452" />
   <package id="GemBox.Document" version="23.3.30.1040" targetFramework="net40" />
   <package id="GemBox.Spreadsheet" version="37.3.30.1110" targetFramework="net40" />
 </packages>

--- a/Plugins/MsCrmTools.UserRolesManager/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.UserRolesManager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.UserSettingsUtility/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.UserSettingsUtility/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.ViewLayoutReplicator/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.ViewLayoutReplicator/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MsCrmTools.WebResourcesManager/Properties/AssemblyInfo.cs
+++ b/Plugins/MsCrmTools.WebResourcesManager/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/Plugins/MscrmTools.SyncFilterManager/Properties/AssemblyInfo.cs
+++ b/Plugins/MscrmTools.SyncFilterManager/Properties/AssemblyInfo.cs
@@ -18,5 +18,5 @@ using System.Security;
 [assembly: ComVisible(false)]
 [assembly: Guid("a8234074-9ff2-4a4c-b580-a2ad4507a116")]
 
-[assembly: AssemblyVersion("1.2015.1.17")]
-[assembly: AssemblyFileVersion("1.2015.1.17")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]

--- a/XrmToolBox/AppCode/GithubVersionChecker.cs
+++ b/XrmToolBox/AppCode/GithubVersionChecker.cs
@@ -39,7 +39,7 @@ namespace XrmToolBox.AppCode
                 client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 client.DefaultRequestHeaders.Add("User-Agent", "MscrmTools");
 
-                HttpResponseMessage response = await client.GetAsync("repos/MsCrmTools/ApplicationParameters/releases").ConfigureAwait(continueOnCapturedContext: false);
+                HttpResponseMessage response = await client.GetAsync("repos/MsCrmTools/XrmToolBox/releases").ConfigureAwait(continueOnCapturedContext: false);
                 response.EnsureSuccessStatusCode();
                 if (response.IsSuccessStatusCode)
                 {
@@ -47,29 +47,31 @@ namespace XrmToolBox.AppCode
                     var jSserializer = new JavaScriptSerializer();
                     var releases = jSserializer.Deserialize<List<RootObject>>(data.Result);
 
-                    var lastRelease = releases.OrderByDescending(r => r.created_at).First();
-
-                    var version = lastRelease.tag_name.Replace("v.", "");
-                    var versionParts = version.Split('.');
-                    int majorVersion = int.Parse(versionParts[0]);
-                    int minorVersion = int.Parse(versionParts[1]);
-                    int buildVersion = int.Parse(versionParts[2]);
-                    int revisionVersion = int.Parse(versionParts[3]);
-
-                    if (currentMajorVersion < majorVersion
-                        || currentMajorVersion == majorVersion && currentMinorVersion < minorVersion
-                        ||
-                        currentMajorVersion == majorVersion && currentMinorVersion == minorVersion &&
-                        currentBuildVersion < buildVersion
-                        ||
-                        currentMajorVersion == majorVersion && currentMinorVersion == minorVersion &&
-                        currentBuildVersion == buildVersion && currentRevisionVersion < revisionVersion)
+                    var lastRelease = releases.OrderByDescending(r => r.created_at).FirstOrDefault();
+                    if (lastRelease != null)
                     {
-                        Cpi = new GithubInformation
+                        var version = lastRelease.tag_name.Replace("v.", "");
+                        var versionParts = version.Split('.');
+                        int majorVersion = int.Parse(versionParts[0]);
+                        int minorVersion = int.Parse(versionParts[1]);
+                        int buildVersion = int.Parse(versionParts[2]);
+                        int revisionVersion = int.Parse(versionParts[3]);
+
+                        if (currentMajorVersion < majorVersion
+                            || currentMajorVersion == majorVersion && currentMinorVersion < minorVersion
+                            ||
+                            currentMajorVersion == majorVersion && currentMinorVersion == minorVersion &&
+                            currentBuildVersion < buildVersion
+                            ||
+                            currentMajorVersion == majorVersion && currentMinorVersion == minorVersion &&
+                            currentBuildVersion == buildVersion && currentRevisionVersion < revisionVersion)
                         {
-                            Description = lastRelease.body,
-                            Version = version
-                        };
+                            Cpi = new GithubInformation
+                            {
+                                Description = lastRelease.body,
+                                Version = version
+                            };
+                        }
                     }
                 }
             }

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -142,7 +142,7 @@ namespace XrmToolBox
 
                 cvc.Run();
 
-                if (!string.IsNullOrEmpty(GithubVersionChecker.Cpi.Version))
+                if (GithubVersionChecker.Cpi != null && !string.IsNullOrEmpty(GithubVersionChecker.Cpi.Version))
                 {
                     if (currentOptions.LastUpdateCheck.Date != DateTime.Now.Date)
                     {

--- a/XrmToolBox/Properties/AssemblyInfo.cs
+++ b/XrmToolBox/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut 
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2015.2.19")]
-[assembly: AssemblyFileVersion("1.2015.2.19")]
+[assembly: AssemblyVersion("1.2015.2.21")]
+[assembly: AssemblyFileVersion("1.2015.2.21")]


### PR DESCRIPTION
Compare produced files: [Gembox](https://onedrive.live.com/redir?resid=286E5C236054BD40!515&authkey=!AJ2pM9PAFk_k3Pc&ithint=file%2cxlsx), [EPPlus](https://onedrive.live.com/redir?resid=286E5C236054BD40!531&authkey=!AOtih5R0BOv8r98&ithint=file%2cxlsx).


## Refactoring notes

Refactoring is done with `#if` macros.

```C#
#if NO_GEMBOX
#else
#endif
```

Use 'Debug' target to build Gembox-dependant version. Use 'Debug without Gembox' for EPPlusversion.


Three primary refactorings:

### Centralising cell styling in `StyleMutator` class.
### Replacing row iterator with cell iterations
by replacing this:

```C#
    foreach (ExcelRow row in sheet.Rows.Where(r => r.Index != 0).OrderBy(r => r.Index))
    {
        var = row.Cells[1].Value;
    }
```

with this:

```C#
var rowsCount = sheet.Dimension.Rows;

for (var rowI = 1; rowI < rowsCount; rowI++)
{
    var = sheet.Cells[rowI, 1].Value;
}
```

### Doing regexp replacement to centralise indexing of cells in `ZeroBasedSheet` class.

We do this kludge to address 1-basedness of EPPlus and 0-basedness of Gembox.

Regexp:

```regexp
(\s|\(){1}(\w*?)\.Cells\[(.*?),\s(.*?)]

$1ZeroBasedSheet.Cell($2, $3, $4)
```