### PR TITLE
Small usability improvements

### DIFF
--- a/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionForm.cs
+++ b/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionForm.cs
@@ -556,7 +556,8 @@ namespace McTools.Xrm.Connection.WinForms
             tbUserLogin.Text = detail.UserName;
             tbUserPassword.Text = detail.UserPassword;
             chkSavePassword.Checked = detail.SavePassword;
-            comboBoxOrganizations.Text = detail.OrganizationFriendlyName;
+            comboBoxOrganizations.Items.Add(detail.OrganizationFriendlyName);
+            comboBoxOrganizations.SelectedIndex = 0;
             cbUseIfd.Checked = detail.UseIfd;
             cbUseOSDP.Checked = detail.UseOsdp;
             cbUseOnline.Checked = detail.UseOnline;

--- a/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionForm.designer.cs
+++ b/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionForm.designer.cs
@@ -435,6 +435,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.bCancel;
             this.ClientSize = new System.Drawing.Size(604, 692);
             this.Controls.Add(this.tbTimeoutValue);
             this.Controls.Add(this.lblTimeoutValue);

--- a/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionSelector.designer.cs
+++ b/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionSelector.designer.cs
@@ -57,6 +57,7 @@
             // bCancel
             // 
             this.bCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.bCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.bCancel.Location = new System.Drawing.Point(468, 375);
             this.bCancel.Name = "bCancel";
             this.bCancel.Size = new System.Drawing.Size(75, 23);
@@ -149,6 +150,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.bCancel;
             this.ClientSize = new System.Drawing.Size(555, 410);
             this.Controls.Add(this.menu);
             this.Controls.Add(this.bValidate);


### PR DESCRIPTION
Closing dialogs with `ESC` — way quicker!