### PR TITLE
Fixing bug with Use SSL checkbox and CRMOL

### DIFF
--- a/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionForm.cs
+++ b/Connection Projects/McTools.Xrm.Connection.WinForms/ConnectionForm.cs
@@ -418,13 +418,20 @@ namespace McTools.Xrm.Connection.WinForms
                 goodServerData = true;
 
             int serverPort = 80;
-            if (tbServerPort.Text.Length > 0)
+            if (cbUseSsl.Checked)
             {
-                if (!int.TryParse(tbServerPort.Text, out serverPort))
+                serverPort = 443;
+            }
+            else
+            {
+                if (tbServerPort.Text.Length > 0)
                 {
-                    MessageBox.Show(this, "Server port must be a integer value!", "Warning", MessageBoxButtons.OK,
-                        MessageBoxIcon.Warning);
-                    return;
+                    if (!int.TryParse(tbServerPort.Text, out serverPort))
+                    {
+                        MessageBox.Show(this, "Server port must be a integer value!", "Warning", MessageBoxButtons.OK,
+                            MessageBoxIcon.Warning);
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
The only real change to this file is the addition of a new check to see if the cbUseSSL checkbox is checked. If it is, it forces the use of 443, otherwise it uses whatever port is in the textbox, or defaults to 80.