### PR TITLE
In the project MetadataBrowser, on the post build event script, added qu...

### DIFF
--- a/Plugins/MsCrmTools.MetadataBrowser/MsCrmTools.MetadataBrowser.csproj
+++ b/Plugins/MsCrmTools.MetadataBrowser/MsCrmTools.MetadataBrowser.csproj
@@ -180,11 +180,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" />
+      <UserProperties BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_ConfigurationName="Release" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>copy /y $(TargetPath) "$(SolutionDir)XrmToolBox\$(OutDir)"</PostBuildEvent>
+    <PostBuildEvent>copy /y "$(TargetPath)" "$(SolutionDir)XrmToolBox\$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/XrmToolBox.sln
+++ b/XrmToolBox.sln
@@ -351,7 +351,6 @@ Global
 		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug Without GemBox|Any CPU.ActiveCfg = Debug Without GemBox|Any CPU
 		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug Without GemBox|Any CPU.Build.0 = Debug Without GemBox|Any CPU
 		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug Without GemBox|Mixed Platforms.ActiveCfg = Debug Without GemBox|Any CPU
-		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug Without GemBox|Mixed Platforms.Build.0 = Debug Without GemBox|Any CPU
 		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug Without GemBox|x86.ActiveCfg = Debug Without GemBox|Any CPU
 		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AEB54313-C622-49F4-8D9A-2D75BFA54901}.Debug|Any CPU.Build.0 = Debug|Any CPU


### PR DESCRIPTION
This pull request contains items that were preventing me from building the solution (from master) after I cloned it.  This may help future developers, so that they don't have to bother with these issues.

In the project MetadataBrowser, on the post build event script, added quotes around the $(TargetPath) like "$(TargetPath)" reasons:
	- the solution was not building because my local path has spaces
	- to make it consistent with the other plugin projects that have the quotes around the $(TargetPath).
	- in case other Developers have spaces in their $(TargetPath) path

In the solution properties removed (unchecked) the project MetadataDocumentGenerator from the Build process on the "Debug without GemBox" configuration, because the project has dependencies on the GemBox LicenseKey.

Great tool.
