### PR TITLE
Loading plugins synchronously. Fixes #56

### DIFF
--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -172,17 +172,6 @@ namespace XrmToolBox
             });
         }
 
-        private Task LaunchPluginsLoad()
-        {
-            return new Task(() =>
-            {
-                pManager = new PluginManager();
-                pManager.LoadPlugins();
-
-                this.DisplayPlugins();
-            });
-        }
-
         #endregion Initialization methods
 
         #region Form events
@@ -191,10 +180,14 @@ namespace XrmToolBox
         {
             this.Opacity = 0;
 
+            pManager = new PluginManager();
+            pManager.LoadPlugins();
+
+            this.DisplayPlugins();
+
             var tasks = new List<Task>
             {
                 this.LaunchWelcomeDialog(),
-                this.LaunchPluginsLoad(),
                 this.LaunchVersionCheck()
             };
             


### PR DESCRIPTION
Reverting asynchronous plugin loading, since there are some cases, when plugin can fail to load (depends on set of the UI properties modified during plugin initialization)