### PR TITLE
Close current plugin using Ctrl+F4 hotkey 

### DIFF
--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -908,7 +908,8 @@ namespace XrmToolBox
             else
             {
                 // Close current plugin on Ctrl+F4
-                if (keyData == (Keys.Control | Keys.F4))
+                if (keyData == (Keys.Control | Keys.F4) ||
+                    keyData == (Keys.Control | Keys.W))
                 {
                     RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseHotKey));
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -910,7 +910,7 @@ namespace XrmToolBox
                 // Close current plugin on Ctrl+F4
                 if (keyData == (Keys.Control | Keys.F4))
                 {
-                    RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseCurrent));
+                    RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseHotKey));
 
                     return true;
                 }

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -909,7 +909,8 @@ namespace XrmToolBox
             {
                 // Close current plugin on Ctrl+F4
                 if (keyData == (Keys.Control | Keys.F4) ||
-                    keyData == (Keys.Control | Keys.W))
+                    keyData == (Keys.Control | Keys.W) ||
+                    keyData == (Keys.Control | Keys.Q))
                 {
                     RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseHotKey));
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -907,7 +907,7 @@ namespace XrmToolBox
             }
             else
             {
-                // Close current plugin on Ctrl+F4
+                // Close current plugin on Ctrl+Q, Ctrl+W and Ctrl+F4
                 if (keyData == (Keys.Control | Keys.Q) ||
                     keyData == (Keys.Control | Keys.W) ||
                     keyData == (Keys.Control | Keys.F4))

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -905,6 +905,16 @@ namespace XrmToolBox
                     return true;
                 }
             }
+            else
+            {
+                // Close current plugin on Ctrl+F4
+                if (keyData == (Keys.Control | Keys.F4))
+                {
+                    RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseCurrent));
+
+                    return true;
+                }
+            }
 
             return base.ProcessCmdKey(ref msg, keyData);
         }

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -908,9 +908,9 @@ namespace XrmToolBox
             else
             {
                 // Close current plugin on Ctrl+F4
-                if (keyData == (Keys.Control | Keys.F4) ||
+                if (keyData == (Keys.Control | Keys.Q) ||
                     keyData == (Keys.Control | Keys.W) ||
-                    keyData == (Keys.Control | Keys.Q))
+                    keyData == (Keys.Control | Keys.F4))
                 {
                     RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseHotKey));
 

--- a/XrmToolBox/PluginCloseInfo.cs
+++ b/XrmToolBox/PluginCloseInfo.cs
@@ -46,6 +46,7 @@ namespace XrmToolBox
         CloseAllExceptActive,
         CloseCurrent,
         CloseMiddleClick,
+        CloseHotKey,
         PluginRequest,
     }
 }


### PR DESCRIPTION
This PR does not close #44, but introduces additional way to close plugin in addition to mouse middle click on plugin's header.