### PR TITLE
Introducing command line parameters

### DIFF
--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -162,7 +162,7 @@ namespace XrmToolBox
 
         private void StartPluginWithoutConnection()
         {
-            if (!string.IsNullOrEmpty(this.initialPluginName))
+            if (!string.IsNullOrEmpty(this.initialPluginName) && this.pManager != null && this.pManager.PluginsControls != null)
             {
                 var pluginControl = this.pManager.PluginsControls.FirstOrDefault(x => ((Type)x.Tag).GetTitle() == this.initialPluginName);
                 if (pluginControl != null)

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -62,8 +62,8 @@ namespace XrmToolBox
         {
             if (args.Length > 0)
             {
-                this.initialConnectionName = ExtractConnectionName(ref args);
-                this.initialPluginName = ExtractPluginName(ref args);
+                this.initialConnectionName = ExtractSwitchValue("/connection:", ref args);
+                this.initialPluginName = ExtractSwitchValue("/plugin:", ref args);
             }
 
             InitializeComponent();
@@ -515,14 +515,19 @@ namespace XrmToolBox
             }
         }
 
-        private string ExtractPluginName(ref string[] args)
+        private string ExtractSwitchValue(string key, ref string[] args)
         {
-            throw new NotImplementedException();
-        }
+            var name = string.Empty;
 
-        private string ExtractConnectionName(ref string[] args)
-        {
-            throw new NotImplementedException();
+            foreach (var arg in args)
+            {
+                if (arg.StartsWith(key))
+                {
+                    name = arg.Substring(key.Length);
+                }
+            }
+
+            return name;
         }
 
         void MainForm_OnCloseTool(object sender, EventArgs e)

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -127,6 +127,8 @@ namespace XrmToolBox
                 {
                     ApplyConnectionToTabs();
                 }
+
+                this.StartPluginWithConnection();
             };
             cManager.ConnectionFailed += (sender, e) =>
             {
@@ -143,6 +145,37 @@ namespace XrmToolBox
             fHelper = new FormHelper(this);
             ccsb = new CrmConnectionStatusBar(fHelper) { Dock = DockStyle.Bottom };
             Controls.Add(ccsb);
+
+            this.StartPluginWithConnection();
+        }
+
+        private void StartPluginWithConnection()
+        {
+            if (!string.IsNullOrEmpty(this.initialConnectionName) && string.IsNullOrEmpty(this.initialPluginName))
+            {
+                this.StartPluginWithoutConnection();
+
+                // Resetting initial connection name
+                this.initialConnectionName = string.Empty;
+            }
+        }
+
+        private void StartPluginWithoutConnection()
+        {
+            if (!string.IsNullOrEmpty(this.initialPluginName))
+            {
+                var pluginControl = this.pManager.PluginsControls.FirstOrDefault(x => ((Type)x.Tag).GetTitle() == this.initialPluginName);
+                if (pluginControl != null)
+                {
+                    this.Invoke(new Action(() =>
+                    {
+                        this.PluginClicked(pluginControl, null);
+                    }));
+                }
+
+                // Resetting initial plugin name
+                this.initialPluginName = string.Empty;
+            }
         }
 
         private Task LaunchVersionCheck()
@@ -194,9 +227,6 @@ namespace XrmToolBox
                 {
                     ConnectionManager.Instance.ConnectToServer(connectionDetail);
                 }
-
-                // Resetting initial connection
-                this.initialConnectionName = string.Empty;
             });
         }
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -132,26 +132,30 @@ namespace XrmToolBox
             };
             cManager.ConnectionFailed += (sender, e) =>
             {
-                Controls.Remove(infoPanel);
-                if (infoPanel != null) infoPanel.Dispose();
+                this.Invoke(new Action(() =>
+                {
+                    Controls.Remove(infoPanel);
+                    if (infoPanel != null) infoPanel.Dispose();
 
-                MessageBox.Show(this, e.FailureReason, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(this, e.FailureReason, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                currentConnectionDetail = null;
-                service = null;
-                ccsb.SetConnectionStatus(false, null);
-                ccsb.SetMessage(e.FailureReason);
+                    currentConnectionDetail = null;
+                    service = null;
+                    ccsb.SetConnectionStatus(false, null);
+                    ccsb.SetMessage(e.FailureReason);
+
+                    this.StartPluginWithConnection();
+                }));
             };
+
             fHelper = new FormHelper(this);
             ccsb = new CrmConnectionStatusBar(fHelper) { Dock = DockStyle.Bottom };
             Controls.Add(ccsb);
-
-            this.StartPluginWithConnection();
         }
 
         private void StartPluginWithConnection()
         {
-            if (!string.IsNullOrEmpty(this.initialConnectionName) && string.IsNullOrEmpty(this.initialPluginName))
+            if (!string.IsNullOrEmpty(this.initialConnectionName) && !string.IsNullOrEmpty(this.initialPluginName))
             {
                 this.StartPluginWithoutConnection();
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -221,16 +221,11 @@ namespace XrmToolBox
             });
         }
 
-        private Task launchInitialConnection()
+        private Task launchInitialConnection(ConnectionDetail connectionDetail)
         {
             return new Task(() =>
             {
-                var connectionDetail = ConnectionManager.Instance.ConnectionsList.Connections.Where(x => x.ConnectionName == this.initialConnectionName).FirstOrDefault(); ;
-
-                if (connectionDetail != null)
-                {
-                    ConnectionManager.Instance.ConnectToServer(connectionDetail);
-                }
+                ConnectionManager.Instance.ConnectToServer(connectionDetail);
             });
         }
 
@@ -255,9 +250,23 @@ namespace XrmToolBox
 
             if (!string.IsNullOrEmpty(this.initialConnectionName))
             {
-                // If initiall connection is present, connect to given sever is initiated.
-                // After connection try to open intial plugin will be attempted.
-                tasks.Add(this.launchInitialConnection());
+                var connectionDetail = ConnectionManager.Instance.ConnectionsList.Connections.FirstOrDefault(x => x.ConnectionName == this.initialConnectionName); ;
+
+                if (connectionDetail != null)
+                {
+                    // If initiall connection is present, connect to given sever is initiated.
+                    // After connection try to open intial plugin will be attempted.
+                    tasks.Add(this.launchInitialConnection(connectionDetail));
+                }
+                else
+                {
+                    // Connection detail was not found, so name provided was incorrect.
+                    // But if name of the plugin is set, it should be started
+                    if (!string.IsNullOrEmpty(this.initialPluginName))
+                    {
+                        this.StartPluginWithoutConnection();
+                    }
+                }
             }
             else if (!string.IsNullOrEmpty(this.initialPluginName))
             {

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -54,7 +54,7 @@ namespace XrmToolBox
 
         #region Constructor
 
-        public MainForm()
+        public MainForm(string[] args)
         {
             InitializeComponent();
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -50,12 +50,22 @@ namespace XrmToolBox
 
         private Panel infoPanel;
 
+        private object initialConnectionName;
+        
+        private object initialPluginName;
+
         #endregion Variables
 
         #region Constructor
 
         public MainForm(string[] args)
         {
+            if (args.Length > 0)
+            {
+                this.initialConnectionName = ExtractConnectionName(ref args);
+                this.initialPluginName = ExtractPluginName(ref args);
+            }
+
             InitializeComponent();
 
             ProcessMenuItemsForPlugin();
@@ -503,6 +513,16 @@ namespace XrmToolBox
                 MessageBox.Show(this, "An error occured when trying to display this plugin: " + error.Message, "Error",
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+        }
+
+        private string ExtractPluginName(ref string[] args)
+        {
+            throw new NotImplementedException();
+        }
+
+        private string ExtractConnectionName(ref string[] args)
+        {
+            throw new NotImplementedException();
         }
 
         void MainForm_OnCloseTool(object sender, EventArgs e)

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -50,9 +50,9 @@ namespace XrmToolBox
 
         private Panel infoPanel;
 
-        private object initialConnectionName;
-        
-        private object initialPluginName;
+        private string initialConnectionName;
+
+        private string initialPluginName;
 
         #endregion Variables
 
@@ -184,6 +184,22 @@ namespace XrmToolBox
             });
         }
 
+        private Task launchInitialConnection()
+        {
+            return new Task(() =>
+            {
+                var connectionDetail = ConnectionManager.Instance.ConnectionsList.Connections.Where(x => x.ConnectionName == this.initialConnectionName).FirstOrDefault(); ;
+
+                if (connectionDetail != null)
+                {
+                    ConnectionManager.Instance.ConnectToServer(connectionDetail);
+                }
+
+                // Resetting initial connection
+                this.initialConnectionName = string.Empty;
+            });
+        }
+
         #endregion Initialization methods
 
         #region Form events
@@ -202,6 +218,11 @@ namespace XrmToolBox
                 this.LaunchWelcomeDialog(),
                 this.LaunchVersionCheck()
             };
+
+            if (!string.IsNullOrEmpty(this.initialConnectionName))
+            {
+                tasks.Add(this.launchInitialConnection());
+            }
             
             tasks.ForEach(x => x.Start());
             

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -173,7 +173,7 @@ namespace XrmToolBox
                 {
                     this.Invoke(new Action(() =>
                     {
-                        this.PluginClicked(pluginControl, null);
+                        this.DisplayPluginControl(pluginControl);
                     }));
                 }
 

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -251,10 +251,13 @@ namespace XrmToolBox
 
             if (!string.IsNullOrEmpty(this.initialConnectionName))
             {
+                // If initiall connection is present, connect to given sever is initiated.
+                // After connection try to open intial plugin will be attempted.
                 tasks.Add(this.launchInitialConnection());
             }
             else if (!string.IsNullOrEmpty(this.initialPluginName))
             {
+                // If there is no initial connection, but initial plugin is set, openning plugin
                 this.StartPluginWithoutConnection();
             }
             

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -253,6 +253,10 @@ namespace XrmToolBox
             {
                 tasks.Add(this.launchInitialConnection());
             }
+            else if (!string.IsNullOrEmpty(this.initialPluginName))
+            {
+                this.StartPluginWithoutConnection();
+            }
             
             tasks.ForEach(x => x.Start());
             

--- a/XrmToolBox/Program.cs
+++ b/XrmToolBox/Program.cs
@@ -30,7 +30,7 @@ namespace XrmToolBox
 
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
-                Application.Run(new MainForm());
+                Application.Run(new MainForm(args));
             }
             catch (Exception error)
             {

--- a/XrmToolBox/Program.cs
+++ b/XrmToolBox/Program.cs
@@ -19,7 +19,7 @@ namespace XrmToolBox
         /// Point d'entrée principal de l'application.
         /// </summary>
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
             try
             {


### PR DESCRIPTION
I left this feature undocumented for end users, but most probably it is interesting for developers. When developing plugin you cannot start it directly, since it's a class library. 

As a way out you're changing `Start action` of the project to the option `Start external program` and pointing to the `XTB` executable in the `Debug` folder.

This works fine, but you still need to perform following actions: 
* choose connection;
* open needed plugin;

To solve this case new command line parameters was added. It is possible to start `XTB` by following statement:

```
XrmToolBox.exe /connection:"Connection Name" /plugin:"Plugin Name"
```

* `Connection Name` is the same as written in ConnectionManager, for example "CRM DEV";
* `Plugin Name` is the same as official plugin's name, for example "A Sample Tool";
* Both parameters accept names with the spaces;
* You can set either both values, or only one;
* In case if no `Connection Name` is set, user will be asked to connect on plugin open;
* In case if no `Plugin Name` is set, `XTB` will just connect to given organization;
* If connection was unsuccessful, the plugin will still be opened;
* In case if `Connection Name` is incorrect, no error will be shown, but connection will not be established;
* In case if `Plugin Name` is incorrect, no error message will be shown, but plugin will not be started;
* Information about initial connection and plugin is erased after processing, so on reconnection to another organization, initial plugin will not be started again.
* Connecting to the initial organization is done asynchronously, while splash-screen is shown. 