### PR TITLE
Updated the string.format formatstring

### DIFF
--- a/Plugins/MsCrmTools.ScriptsFinder/ScriptsFinder.cs
+++ b/Plugins/MsCrmTools.ScriptsFinder/ScriptsFinder.cs
@@ -113,7 +113,7 @@ namespace MsCrmTools.ScriptsFinder
                     
                     foreach (ListViewItem item in lvScripts.Items)
                     {
-                        var line = System.Text.Encoding.UTF8.GetBytes(string.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8}{9}",
+                        var line = System.Text.Encoding.UTF8.GetBytes(string.Format("{0},{1},{2},{3},{4},{5},{6},{7},{8},{9}{10}",
                             item.SubItems[0].Text,
                             item.SubItems[1].Text,
                             item.SubItems[2].Text,


### PR DESCRIPTION
The formatstring only had placeholders for 10 arguments when (including the newline) there are 11 arguments being passed in.