### PR TITLE
Adding check on `null`

### DIFF
--- a/Plugins/MsCrmTools.SiteMapEditor/SiteMapEditor.cs
+++ b/Plugins/MsCrmTools.SiteMapEditor/SiteMapEditor.cs
@@ -560,6 +560,9 @@ namespace MsCrmTools.SiteMapEditor
 
         private void TvSiteMapKeyDown(object sender, KeyEventArgs e)
         {
+            if (tvSiteMap.SelectedNode == null)
+                return;
+
             if (tvSiteMap.SelectedNode.Text != "SiteMap")
             {
                 // Cut


### PR DESCRIPTION
Check prevents `XTB` from crash when SiteMap is not yet loaded into plugin.