### PR TITLE
Unifying plugin handling after MEF migration fixes Message Bus

### DIFF
--- a/XrmToolBox/MainForm.PluginsManagement.cs
+++ b/XrmToolBox/MainForm.PluginsManagement.cs
@@ -173,22 +173,20 @@ namespace XrmToolBox
             top += pm.Height + 4;
         }
 
-        private int DisplayPluginControl(UserControl plugin)
+        private int DisplayPluginControl(Lazy<IXrmToolBoxPlugin, IPluginMetadata> plugin)
         {
             var tabIndex = 0;
 
             try
             {
-                var control = (Lazy<IXrmToolBoxPlugin, IPluginMetadata>)plugin.Tag;
-                var pluginControl = (UserControl)control.Value.GetControl();
+                var pluginControl = (UserControl)plugin.Value.GetControl();
              
                 if (service != null)
                 {
                     var clonedService = (OrganizationService)currentConnectionDetail.GetOrganizationService();
                     ((OrganizationServiceProxy)clonedService.InnerService).SdkClientVersion = currentConnectionDetail.OrganizationVersion;
 
-                    ((IXrmToolBoxPluginControl)pluginControl).UpdateConnection(clonedService,
-                        currentConnectionDetail);
+                    ((IXrmToolBoxPluginControl)pluginControl).UpdateConnection(clonedService, currentConnectionDetail);
                 }
 
                 // ReSharper disable once SuspiciousTypeConversion.Global
@@ -201,7 +199,7 @@ namespace XrmToolBox
                 ((IXrmToolBoxPluginControl)pluginControl).OnRequestConnection += MainForm_OnRequestConnection;
                 ((IXrmToolBoxPluginControl)pluginControl).OnCloseTool += MainForm_OnCloseTool;
 
-                string name = string.Format("{0} ({1})", control.Metadata.Name,
+                string name = string.Format("{0} ({1})", plugin.Metadata.Name,
                     currentConnectionDetail != null
                         ? currentConnectionDetail.ConnectionName
                         : "Not connected");
@@ -219,27 +217,26 @@ namespace XrmToolBox
 
                 tabControl1.SelectTab(tabIndex);
 
-                var pluginInOption =
-                    currentOptions.MostUsedList.FirstOrDefault(i => i.Name == control.Value.GetType().FullName);
+                var pluginInOption = currentOptions.MostUsedList.FirstOrDefault(i => i.Name == plugin.Value.GetType().FullName);
                 if (pluginInOption == null)
                 {
-                    pluginInOption = new PluginUseCount { Name = control.Value.GetType().FullName, Count = 0 };
+                    pluginInOption = new PluginUseCount { Name = plugin.Value.GetType().FullName, Count = 0 };
                     currentOptions.MostUsedList.Add(pluginInOption);
                 }
 
                 pluginInOption.Count++;
 
-                var p1 = plugin as SmallPluginModel;
-                if (p1 != null)
-                    p1.UpdateCount(pluginInOption.Count);
-                else
-                {
-                    var p2 = plugin as LargePluginModel;
-                    if (p2 != null)
-                    {
-                        p2.UpdateCount(pluginInOption.Count);
-                    }
-                }
+                //var p1 = plugin as SmallPluginModel;
+                //if (p1 != null)
+                //    p1.UpdateCount(pluginInOption.Count);
+                //else
+                //{
+                //    var p2 = plugin as LargePluginModel;
+                //    if (p2 != null)
+                //    {
+                //        p2.UpdateCount(pluginInOption.Count);
+                //    }
+                //}
 
                 if (currentOptions.LastAdvertisementDisplay == new DateTime() ||
                     currentOptions.LastAdvertisementDisplay > DateTime.Now ||
@@ -248,8 +245,7 @@ namespace XrmToolBox
                     bool displayAdvertisement = true;
                     try
                     {
-                        var assembly =
-                            Assembly.LoadFile(new FileInfo(Assembly.GetExecutingAssembly().Location).Directory +
+                        var assembly = Assembly.LoadFile(new FileInfo(Assembly.GetExecutingAssembly().Location).Directory +
                                               "\\McTools.StopAdvertisement.dll");
                         if (assembly != null)
                         {
@@ -283,7 +279,7 @@ namespace XrmToolBox
 
                 if (currentOptions.AllowLogUsage.HasValue && currentOptions.AllowLogUsage.Value)
                 {
-                    LogUsage.DoLog(control);
+                    LogUsage.DoLog(plugin);
                 }
 
                 currentOptions.Save();

--- a/XrmToolBox/PluginManagerExtended.cs
+++ b/XrmToolBox/PluginManagerExtended.cs
@@ -5,7 +5,6 @@ using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Windows.Forms;
 using XrmToolBox.Extensibility.Interfaces;
-using XrmToolBox.Extensibility.UserControls;
 
 namespace XrmToolBox
 {
@@ -16,7 +15,6 @@ namespace XrmToolBox
         public PluginManagerExtended(Form parentForm)
         {
             lastPluginsUpdate = DateTime.Now;
-            PluginsControls = new List<PluginModel>();
 
             var watcher = new FileSystemWatcher(PluginPath)
             {
@@ -31,15 +29,9 @@ namespace XrmToolBox
         [ImportMany(AllowRecomposition = true)]
         public IEnumerable<Lazy<IXrmToolBoxPlugin, IPluginMetadata>> Plugins { get; set; }
 
-        /// <summary>
-        /// List of plugins user controls
-        /// </summary>
-        public List<PluginModel> PluginsControls { get; private set; }
-
-
         private CompositionContainer container;
         private DirectoryCatalog directoryCatalog;
-        private static readonly string PluginPath = Path.Combine(AppDomain.CurrentDomain.SetupInformation.ApplicationBase,"Plugins");
+        private static readonly string PluginPath = Path.Combine(AppDomain.CurrentDomain.SetupInformation.ApplicationBase, "Plugins");
 
         public event EventHandler PluginsListUpdated;
 
@@ -57,16 +49,16 @@ namespace XrmToolBox
         {
             try
             {
-                ((FileSystemWatcher) sender).EnableRaisingEvents = false;
+                ((FileSystemWatcher)sender).EnableRaisingEvents = false;
 
                 PluginsListUpdated(this, new EventArgs());
             }
             finally
             {
-                ((FileSystemWatcher) sender).EnableRaisingEvents = true;
+                ((FileSystemWatcher)sender).EnableRaisingEvents = true;
             }
         }
-        
+
         public void Recompose()
         {
             directoryCatalog.Refresh();

--- a/XrmToolBox/PluginUseCount.cs
+++ b/XrmToolBox/PluginUseCount.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace XrmToolBox
+﻿namespace XrmToolBox
 {
     public class PluginUseCount
     {


### PR DESCRIPTION
There is a problem with Message Bus.

When migration to `MEF` occurred, a lot of confusion was introduced to code. Before that it was only two possible types of input arguments to plugin manipulation functions: 
* the actual plugin control
* the plugin model (plugin representation in plugins list)

Currently third type was added: `Lazy<IXrmToolBoxPlugin, IPluginMetadata>`. And calls to previous objects was not eliminated, but these objects itself has become obsolete. 

The worst part of it that variable `PluginManagerExtended.PluginsControls` become obsolete. It always empty. And since `Message Bus` relays on this object it stopped working.

I developed the fix and tried to unify approaches. To use `Lazy<IXrmToolBoxPlugin, IPluginMetadata>` everywhere. But this lead to one unpleasant effect.

Since model control is not available, visual update of plugin usage counter will not be applied until list is not reloaded. I left that [code commented](https://github.com/MscrmTools/XrmToolBox/compare/master...Cinteros:message-bus?expand=1#diff-68a72fad027803ad1303c771a44e3e38R229). 

Logical grounding that I can come up with is following: the the function itself is about displaying single plugin, but not about updating list of plugins. And if plugin will be started not from click (command line or message bus) the model control will not be available anyway.

@MscrmTools could you please review and consider this code for merging with main codebase?