### PR TITLE
WorkAsyc shortcut for operations that don't require callback

### DIFF
--- a/XrmToolBox.Extensibility/Interfaces/IWorkerHost.cs
+++ b/XrmToolBox.Extensibility/Interfaces/IWorkerHost.cs
@@ -13,6 +13,8 @@ namespace XrmToolBox.Extensibility.Interfaces
     {
         Control.ControlCollection Controls { get; }
 
+        void WorkAsync(string message, Action<DoWorkEventArgs> work, object argument, int messageWidth, int messageHeight);
+
         void WorkAsync(string message, Action<DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, object argument, int messageWidth, int messageHeight);
 
         void WorkAsync(string message, Action<BackgroundWorker, DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, Action<ProgressChangedEventArgs> progressChanged, object argument, int messageWidth, int messageHeight);

--- a/XrmToolBox.Extensibility/PluginControlBase.cs
+++ b/XrmToolBox.Extensibility/PluginControlBase.cs
@@ -106,6 +106,11 @@ namespace XrmToolBox.Extensibility
 
         private readonly Worker _worker = new Worker();
 
+        public void WorkAsync(string message, Action<DoWorkEventArgs> work, object argument = null, int messageWidth = 340, int messageHeight = 150)
+        {
+            _worker.WorkAsync(this, message, work, (x) => { }, argument, messageWidth, messageHeight);
+        }
+
         public void WorkAsync(string message, Action<DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, object argument = null, int messageWidth = 340, int messageHeight = 150)
         {
             _worker.WorkAsync(this, message, work, callback, argument, messageWidth, messageHeight);


### PR DESCRIPTION
I've created shortcut for calling asynchronous operations that do not require callback function to be executed.

So if previously you would wrote code like this:

```
this.WorkAsync("Saving changes",
    a =>
    {
        this.Service.Update(entity);
    },
    a =>
    {
    });
```

Currently it would be just enough to wrote a bit smaller piece of code:

```
this.WorkAsync("Saving changes",
    a =>
    {
        this.Service.Update(entity);
    });
```

Not a huge difference, but makes code cleaner.