### PR TITLE
Specify ConfigurationFile on ConnectionManager

### DIFF
--- a/Connection Projects/McTools.Xrm.Connection/Properties/AssemblyInfo.cs
+++ b/Connection Projects/McTools.Xrm.Connection/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut
 // en utilisant '*', comme indiqué ci-dessous :
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.3315.606")]
-[assembly: AssemblyFileVersion("1.0.3315.606")]
+[assembly: AssemblyVersion("1.2015.10.607")]
+[assembly: AssemblyFileVersion("1.2015.10.607")]


### PR DESCRIPTION
This change introduces the possibility to specify static property ConfigurationFile on the ConnectionManager class.
Sample code to place file ``Connections.config`` in current user's AppData folder for ``Sample App``:
```
ConnectionManager.ConfigurationFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Sample App", "Connections.config");
```
