### PR TITLE
Dev

### DIFF
--- a/Plugins/MsCrmTools.SecurityRelated/UserRolesManager/AppCode/RoleManager.cs
+++ b/Plugins/MsCrmTools.SecurityRelated/UserRolesManager/AppCode/RoleManager.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace MsCrmTools.UserRolesManager.AppCode
+{
+    internal class RoleManager
+    {
+        private readonly IOrganizationService service;
+
+        public RoleManager(IOrganizationService service)
+        {
+            this.service = service;
+        }
+
+        public List<Entity> GetRoles()
+        {
+            return service.RetrieveMultiple(new QueryExpression("role") { ColumnSet = new ColumnSet(true) }).Entities.ToList();
+        }
+
+        public Guid GetRootBusinessUnitId()
+        {
+            return service.RetrieveMultiple(new QueryExpression("businessunit")
+            {
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                {
+                    new ConditionExpression("parentbusinessunitid", ConditionOperator.Null)
+                }
+                }
+            }).Entities.First().Id;
+        }
+
+        public void AddRolesToPrincipals(List<Entity> roles, List<Entity> principals, List<Entity> allRoles, BackgroundWorker worker = null)
+        {
+            int total = principals.Count * roles.Count;
+            int current = 0;
+
+            foreach (var principal in principals)
+            {
+                foreach (var role in roles)
+                {
+                    if (worker != null && worker.WorkerReportsProgress)
+                    {
+                        worker.ReportProgress(current * 100 / total, "Adding roles to principals ({0} %)...");
+                    }
+
+                    var roleToUse = role;
+                    if (allRoles != null)
+                    {
+                        var currentPrincipalBuId = principal.GetAttributeValue<EntityReference>("businessunitid").Id;
+                        if (role.GetAttributeValue<EntityReference>("businessunitid").Id != currentPrincipalBuId)
+                        {
+                            roleToUse = GetRoleRecursive(currentPrincipalBuId, new List<Entity> { role }, allRoles);
+                        }
+                    }
+
+                    try
+                    {
+                        service.Associate(
+                             principal.LogicalName,
+                             principal.Id,
+                             new Relationship(principal.LogicalName + "roles_association"),
+                             new EntityReferenceCollection { roleToUse.ToEntityReference() });
+                    }
+                    catch (Exception error)
+                    {
+
+                    }
+
+                    current++;
+                }
+                //service.Associate(
+                //    principal.LogicalName,
+                //    principal.Id,
+                //    new Relationship(principal.LogicalName + "roles_association"),
+                //    new EntityReferenceCollection(roles.Select(r => r.ToEntityReference()).ToList()));
+            }
+        }
+
+        public void RemoveRolesFromPrincipals(List<Entity> roles, List<Entity> principals, List<Entity> allRoles, BackgroundWorker worker = null)
+        {
+            int total = principals.Count * roles.Count;
+            int current = 0;
+
+            foreach (var principal in principals)
+            {
+                foreach (var role in roles)
+                {
+                    if (worker != null && worker.WorkerReportsProgress)
+                    {
+                        worker.ReportProgress(current * 100 / total, "Removing roles from principals ({0} %)...");
+                    }
+
+                    var roleToUse = role;
+
+                    if (allRoles != null)
+                    {
+                        var currentPrincipalBuId = principal.GetAttributeValue<EntityReference>("businessunitid").Id;
+                        if (role.GetAttributeValue<EntityReference>("businessunitid").Id != currentPrincipalBuId)
+                        {
+                            roleToUse = GetRoleRecursive(currentPrincipalBuId, new List<Entity> { role }, allRoles);
+                        }
+                    }
+
+                    try
+                    {
+                        service.Disassociate(
+                            principal.LogicalName,
+                            principal.Id,
+                            new Relationship(principal.LogicalName + "roles_association"),
+                            new EntityReferenceCollection { roleToUse.ToEntityReference() });
+                    }
+                    catch (Exception error)
+                    {
+
+                    }
+
+                    current++;
+                }
+                //service.Disassociate(
+                //    principal.LogicalName,
+                //    principal.Id,
+                //    new Relationship(principal.LogicalName + "roles_association"),
+                //    new EntityReferenceCollection(roles.Select(r => r.ToEntityReference()).ToList()));
+            }
+        }
+
+        public void RemoveExistingRolesFromPrincipals(List<Entity> principals, BackgroundWorker worker = null)
+        {
+            if (principals.First().LogicalName == "systemuser")
+            {
+                var links = service.RetrieveMultiple(new QueryExpression("systemuserroles")
+                {
+                    ColumnSet = new ColumnSet(true),
+                    Criteria = new FilterExpression
+                    {
+                        Conditions =
+                        {
+                            new ConditionExpression("systemuserid", ConditionOperator.In, principals.Select(p => p.Id).ToArray())
+                        }
+                    },
+                });
+
+                int total = links.Entities.Count;
+                int current = 0;
+
+                foreach (var link in links.Entities)
+                {
+                    if (worker != null && worker.WorkerReportsProgress)
+                    {
+                        worker.ReportProgress(current * 100 / total, "Removing roles from principals ({0} %)...");
+                    }
+
+                    RemoveRolesFromPrincipals(new List<Entity>
+                    {
+                        new Entity("role") {Id = link.GetAttributeValue<Guid>("roleid")}
+                    },
+                        new List<Entity>
+                        {
+                            new Entity("systemuser") {Id = link.GetAttributeValue<Guid>("systemuserid")}
+                        },
+                        null,
+                        worker);
+
+                    current++;
+                }
+            }
+            else
+            {
+                var links = service.RetrieveMultiple(new QueryExpression("teamroles")
+                {
+                    ColumnSet = new ColumnSet(true),
+                    Criteria = new FilterExpression
+                    {
+                        Conditions =
+                        {
+                            new ConditionExpression("teamid", ConditionOperator.In, principals.Select(p => p.Id).ToArray())
+                        }
+                    }
+                });
+
+                int total = links.Entities.Count;
+                int current = 0;
+
+                foreach (var link in links.Entities)
+                {
+                    if (worker != null && worker.WorkerReportsProgress)
+                    {
+                        worker.ReportProgress(current * 100 / total, "Removing roles from principals ({0} %)...");
+                    }
+
+                    RemoveRolesFromPrincipals(new List<Entity>
+                    {
+                        new Entity("role") {Id = link.GetAttributeValue<Guid>("roleid")}
+                    },
+                        new List<Entity>
+                        {
+                            new Entity("team") {Id = link.GetAttributeValue<Guid>("teamid")}
+                        },
+                        null,
+                        worker);
+
+                    current++;
+                }
+            }
+        }
+
+        Entity GetRoleRecursive(Guid buId, List<Entity> roles, List<Entity> allRoles)
+        {
+            if (roles == null || allRoles == null)
+            {
+                return null;
+            }
+
+            foreach (var role in roles)
+            {
+                if (role.GetAttributeValue<EntityReference>("businessunitid").Id == buId)
+                {
+                    return role;
+                }
+
+                var childRole = GetRoleRecursive(buId,
+                       allRoles.Where(a => a.GetAttributeValue<EntityReference>("parentroleid") != null && a.GetAttributeValue<EntityReference>("parentroleid").Id == role.Id).ToList(),
+                       allRoles);
+
+                if (childRole != null)
+                {
+                    return childRole;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Plugins/MsCrmTools.WebResourcesManager/MsCrmTools.WebResourcesManager.csproj
+++ b/Plugins/MsCrmTools.WebResourcesManager/MsCrmTools.WebResourcesManager.csproj
@@ -363,11 +363,11 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>"$(SolutionDir)packages\LibZ.Bootstrap.1.1.0.2\tools\libz.exe" inject-dll --assembly "$(TargetPath)" --include MsCrmTools.WebResourcesManager.dll --include ICSharpCode.AvalonEdit.dll --include Yahoo.Yui.Compressor.dll --include EcmaScript.NET.modified.dll
-xcopy $(TargetPath) "$(SolutionDir)XrmToolBox\$(OutDir)Plugins\$(TargetFileName)" /R /Y</PostBuildEvent>
+xcopy "$(TargetPath)" "$(SolutionDir)XrmToolBox\$(OutDir)Plugins\" /R /Y</PostBuildEvent>
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" BuildVersion_ConfigurationName="Release" />
+      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" />
     </VisualStudio>
   </ProjectExtensions>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/XrmToolBox.Extensibility/Interfaces/IWorkerHost.cs
+++ b/XrmToolBox.Extensibility/Interfaces/IWorkerHost.cs
@@ -17,16 +17,6 @@ namespace XrmToolBox.Extensibility.Interfaces
 
         void SetWorkingMessage(string message, int width, int height);
 
-        void WorkAsync(string message, Action<DoWorkEventArgs> work, object argument, int messageWidth, int messageHeight);
-
-        void WorkAsync(string message, Action<DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, object argument, int messageWidth, int messageHeight);
-
-        void WorkAsync(string message, Action<BackgroundWorker, DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, Action<ProgressChangedEventArgs> progressChanged, object argument, int messageWidth, int messageHeight);
-
-        void WorkAsync(string message, Action<BackgroundWorker, DoWorkEventArgs> work, object argument, bool enableCancellation, int messageWidth, int messageHeight);
-
-        void WorkAsync(string message, Action<BackgroundWorker, DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, object argument, bool enableCancellation, int messageWidth, int messageHeight);
-
-        void WorkAsync(string message, Action<BackgroundWorker, DoWorkEventArgs> work, Action<RunWorkerCompletedEventArgs> callback, Action<ProgressChangedEventArgs> progressChanged, object argument, bool enableCancellation, int messageWidth, int messageHeight);
+        void WorkAsync(WorkAsyncInfo info);
     }
 }

--- a/XrmToolBox.Extensibility/WorkAsyncInfo.cs
+++ b/XrmToolBox.Extensibility/WorkAsyncInfo.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows.Forms;
+
+namespace XrmToolBox.Extensibility
+{
+    public class WorkAsyncInfo
+    {
+        public Control Host { get; set; }
+        public string Message { get; private set; }
+        /// <summary>
+        /// Gets or sets the work to be performed Asynchronously.
+        /// </summary>
+        /// <value>
+        /// The work.
+        /// </value>
+        public Action<BackgroundWorker, DoWorkEventArgs> Work { get; private set; }
+        public bool IsCancelable { get; set; }
+        public object AsyncArgument { get; set; }
+        public Action<RunWorkerCompletedEventArgs> PostWorkCallBack { get; set; }
+        public Action<ProgressChangedEventArgs> ProgressChanged { get; set; }
+        public int MessageWidth { get; set; }
+        public int MessageHeight { get; set; }
+
+        private WorkAsyncInfo(string message)
+        {
+            Message = message;
+            MessageWidth = 340;
+            MessageHeight = 150;
+            IsCancelable = false;
+        }
+
+        /// <summary>
+        /// Constructor for non cancelable Work
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="work">The work.</param>
+        public WorkAsyncInfo(string message, Action<DoWorkEventArgs> work) : this(message, (s, e) => { work(e); })
+        {
+        }
+
+        /// <summary>
+        /// Constructor for cancelable Work
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="work">The work.</param>
+        public WorkAsyncInfo(string message, Action<BackgroundWorker, DoWorkEventArgs> work) : this( message)
+        {
+            Work = work;
+        }
+
+        internal void PerformWork(object worker, DoWorkEventArgs args)
+        {
+            Work((BackgroundWorker) worker, args);
+        }
+
+        internal void PerformProgressChange(object worker, ProgressChangedEventArgs args)
+        {
+            ProgressChanged(args);
+        }
+    }
+}

--- a/XrmToolBox.Extensibility/XrmToolBox.Extensibility.csproj
+++ b/XrmToolBox.Extensibility/XrmToolBox.Extensibility.csproj
@@ -109,6 +109,7 @@
       <DependentUpon>SmallPluginModel.cs</DependentUpon>
     </Compile>
     <Compile Include="Worker.cs" />
+    <Compile Include="WorkAsyncInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Connection Projects\McTools.Xrm.Connection.WinForms\McTools.Xrm.Connection.WinForms.csproj">


### PR DESCRIPTION
Every time we change the Interface, it is a potentially breaking change.  Created an Info object to isolate us from those changes.  Theoretically we should update all calls to the WorkAsync calls to use the WorkAsyncInfo Overload, and then remove the Obsolete Methods entirely.