### PR TITLE
Handle release note parsing errors in GithubVersionChecker

### DIFF
--- a/XrmToolBox/AppCode/GithubVersionChecker.cs
+++ b/XrmToolBox/AppCode/GithubVersionChecker.cs
@@ -81,10 +81,10 @@ namespace XrmToolBox.AppCode
                                 currentBuildVersion == buildVersion && currentRevisionVersion < revisionVersion)
                             {
                                 var mdth = new Markdown();
-                                var html = "";
+                                var html = string.Empty;
                                 try
                                 {
-                                    html = mdth.Transform(lastRelease.body).Replace("h1", "div");
+                                    html = mdth.Transform(lastRelease.body);
                                 }
                                 catch
                                 {

--- a/XrmToolBox/AppCode/GithubVersionChecker.cs
+++ b/XrmToolBox/AppCode/GithubVersionChecker.cs
@@ -81,7 +81,15 @@ namespace XrmToolBox.AppCode
                                 currentBuildVersion == buildVersion && currentRevisionVersion < revisionVersion)
                             {
                                 var mdth = new Markdown();
-                                var html = mdth.Transform(lastRelease.body).Replace("h1", "div");
+                                var html = "";
+                                try
+                                {
+                                    html = mdth.Transform(lastRelease.body).Replace("h1", "div");
+                                }
+                                catch
+                                {
+                                    html = "<br/><br/><i>Unable to load release notes.<br/>Click the Download button to read what's new!</i>";
+                                }
 
                                 Cpi = new GithubInformation
                                 {

--- a/XrmToolBox/AppCode/Markdown.cs
+++ b/XrmToolBox/AppCode/Markdown.cs
@@ -1510,6 +1510,7 @@ namespace MarkdownSharp
             // delimiters in inline links like [this](<url>).
             text = DoAutoLinks(text);
 
+            text = text.Replace("\n", "<br />\n");
             text = text.Replace(AutoLinkPreventionMarker, "://");
 
             text = EncodeAmpsAndAngles(text);

--- a/XrmToolBox/AppCode/Markdown.cs
+++ b/XrmToolBox/AppCode/Markdown.cs
@@ -1282,9 +1282,15 @@ namespace MarkdownSharp
                 {
                     string list = match.Groups[1].Value;
                     string marker = match.Groups[3].Value;
+
+                    if (string.IsNullOrEmpty(list) || string.IsNullOrEmpty(marker))
+                    {
+                        return string.Empty;
+                    }
+
                     string listType = Regex.IsMatch(marker, _markerUL) ? "ul" : "ol";
                     string result;
-                    string start = "";
+                    string start = string.Empty;
                     if (listType == "ol")
                     {
                         var firstNumber = int.Parse(marker.Substring(0, marker.Length - 1));

--- a/XrmToolBox/AppCode/Markdown.cs
+++ b/XrmToolBox/AppCode/Markdown.cs
@@ -348,7 +348,7 @@ namespace MarkdownSharp
         private static Regex _endCharRegex = new Regex(_charEndingUrl, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static Regex _headerAtx = new Regex(@"
-                ^(\#{1,6})  # $1 = string of #'s
+                ^(\#{1,6}\s)  # $1 = string of #'s
                 [ ]*
                 (.+?)       # $2 = Header text
                 [ ]*


### PR DESCRIPTION
More forgiving treatment of release notes, as the Markdown transformer unexpectedly fails sometimes.