### PR TITLE
Use default credentials when getting settings from IE

### DIFF
--- a/XrmToolBox/AppCode/WebProxyHelper.cs
+++ b/XrmToolBox/AppCode/WebProxyHelper.cs
@@ -32,6 +32,9 @@ namespace XrmToolBox.AppCode
             else if (ConnectionManager.Instance.ConnectionsList.UseInternetExplorerProxy)
             {
                 WebRequest.DefaultWebProxy = WebRequest.GetSystemWebProxy();
+                //Use default credentials if no proxy credentials
+                if (WebRequest.DefaultWebProxy.Credentials == null)
+                    WebRequest.DefaultWebProxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
             }
             else
             {


### PR DESCRIPTION
Fix issue #330 