### PR TITLE
Information panel not closed if PostWorkCallBack is not defined

### DIFF
--- a/XrmToolBox.Extensibility/Worker.cs
+++ b/XrmToolBox.Extensibility/Worker.cs
@@ -65,18 +65,18 @@ namespace XrmToolBox.Extensibility
                 _worker.ProgressChanged += info.PerformProgressChange;
             }
 
-            if (info.PostWorkCallBack != null)
+            _worker.RunWorkerCompleted += (s, e) =>
             {
-                _worker.RunWorkerCompleted += (s, e) =>
+                if (info.Host.Controls.Contains(_infoPanel))
                 {
-                    if (info.Host.Controls.Contains(_infoPanel))
-                    {
-                        _infoPanel.Dispose();
-                        info.Host.Controls.Remove(_infoPanel);
-                    }
+                    _infoPanel.Dispose();
+                    info.Host.Controls.Remove(_infoPanel);
+                }
+                if (info.PostWorkCallBack != null)
+                {
                     info.PostWorkCallBack(e);
-                };
-            }
+                }
+            };
 
             _worker.RunWorkerAsync(info.AsyncArgument);
         }


### PR DESCRIPTION
Following code will be executed, but informational panel won't be closed:

```
var instruction = new WorkAsyncInfo()
{
    Message = "Refreshing assemblies information...",
    Work = (worker, argument) =>
    {
        try
        {
            OrganizationHelper.RefreshConnection(this.m_org, OrganizationHelper.LoadMessages(this.m_org));
            Invoke(new Action(() =>
            {
                propGridEntity.SelectedObject = null;
                LoadNodes();
            }));
        }
        catch (Exception ex)
        {
            Invoke(new Action(() =>
            {
                ErrorMessageForm.ShowErrorMessageBox(this, "Unable to the refresh the organization. Connection must close.", "Connection Error", ex);
            }));
        }
    }
};
WorkAsync(instruction);
```

To make it work  again empty `PostWorkCallBack` should be defined:

```
var instruction = new WorkAsyncInfo()
{
    Message = "Refreshing assemblies information...",
    Work = (worker, argument) =>
    {
        try
        {
            OrganizationHelper.RefreshConnection(this.m_org, OrganizationHelper.LoadMessages(this.m_org));
            Invoke(new Action(() =>
            {
                propGridEntity.SelectedObject = null;
                LoadNodes();
            }));
        }
        catch (Exception ex)
        {
            Invoke(new Action(() =>
            {
                ErrorMessageForm.ShowErrorMessageBox(this, "Unable to the refresh the organization. Connection must close.", "Connection Error", ex);
            }));
        }
    },
    PostWorkCallBack = (argument) =>
    {

    }
};
WorkAsync(instruction);
```

The code eliminates need of empty `PostWorkCallBack` for proper operation.