### PR TITLE
Avoiding firing and hiding exception during startup advertisement check

### DIFF
--- a/XrmToolBox/Forms/WelcomeDialog.cs
+++ b/XrmToolBox/Forms/WelcomeDialog.cs
@@ -38,24 +38,25 @@ namespace XrmToolBox.Forms
         {
             try
             {
-                var location = Assembly.GetExecutingAssembly().Location;
-                var fiLocation = new FileInfo(location);
-                var assembly = Assembly.LoadFile(fiLocation.Directory + "\\McTools.StopAdvertisement.dll");
+                var stopAdvertisementLocation = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "McTools.StopAdvertisement.dll");
 
-                if (assembly != null)
+                if (File.Exists(stopAdvertisementLocation))
                 {
-                    Type type = assembly.GetType("McTools.StopAdvertisement.LicenseManager");
-                    if (type == null) { return; }
+                    var type = Assembly.LoadFile(stopAdvertisementLocation).GetType("McTools.StopAdvertisement.LicenseManager");
+                    if (type == null)
+                    {
+                        return;
+                    }
 
-                    MethodInfo methodInfo = type.GetMethod("IsValid");
+                    var methodInfo = type.GetMethod("IsValid");
                     if (methodInfo == null) { return; }
 
                     object classInstance = Activator.CreateInstance(type, null);
 
                     if ((bool)methodInfo.Invoke(classInstance, null))
                     {
-                        PropertyInfo userNameInfo = type.GetProperty("UserName");
-                        PropertyInfo orgNameInfo = type.GetProperty("OrganizationName");
+                        var userNameInfo = type.GetProperty("UserName");
+                        var orgNameInfo = type.GetProperty("OrganizationName");
 
                         var userName = userNameInfo.GetValue(classInstance, null).ToString();
                         var orgName = orgNameInfo.GetValue(classInstance, null).ToString();
@@ -76,11 +77,6 @@ namespace XrmToolBox.Forms
             {
                 MessageBox.Show(this,
                     "It seems you maybe forgot to unblock XrmToolBox.zip before extracting it. XrmToolBox can't work as expected until you unblocked all files. To do so, display XrmToolBox.zip properties and unblock the file before extracting it", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
-            finally
-            {
-                //pnlSupport.Visible = false;
-                //panel2.Visible = true;
             }
         }
 


### PR DESCRIPTION
`ManageLicense()` method in `WelcomeDialog.cs` is not optimal. It designed in the way to fire an exception if `McTools.StopAdvertisement.dll` was not found, and after hide this exception as not important.

Not a big deal actually, and does not affect users either, through still annoying during `XrmToolBox` development / debugging, since it fires all the time.

This is small fix checks presence of file on disk in advance, before trying to access it, thus avoiding unnecessary exception. 