### PR TITLE
Metadoc generator: Default picklist value "N/A" instead of "-1" when not set.

### DIFF
--- a/Plugins/MsCrmTools.MetadataDocumentGenerator/Generation/ExcelDocument.cs
+++ b/Plugins/MsCrmTools.MetadataDocumentGenerator/Generation/ExcelDocument.cs
@@ -751,7 +751,7 @@ namespace MsCrmTools.MetadataDocumentGenerator.Generation
                                 }
                             }
 
-                            format += string.Format("\r\nDefault: {0}", pamd.DefaultFormValue.HasValue ? pamd.DefaultFormValue.Value.ToString(CultureInfo.InvariantCulture) : "N/A");
+                            format += string.Format("\r\nDefault: {0}", pamd.DefaultFormValue.HasValue && pamd.DefaultFormValue.Value != -1 ? pamd.DefaultFormValue.Value.ToString(CultureInfo.InvariantCulture) : "N/A");
 
                             sheet.Cells[x, y].Value = (format);
                         }


### PR DESCRIPTION
The SDK reports -1 as default value when there's no default value assigned. When extracting a picklist attribute the -1 gets in the excel file. 

Updated document generation to print "N/A" as default when SDK reports -1.