### PR TITLE
Correcting behavior of Assembly Recovery Tool

### DIFF
--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/AppCode/AssemblyManager.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/AppCode/AssemblyManager.cs
@@ -85,7 +85,9 @@ namespace MsCrmTools.AssemblyRecoveryTool.AppCode
         /// <returns></returns>
         public byte[] RetrieveAssembly(Guid id)
         {
-            throw new NotImplementedException();
+            var response = service.Retrieve("pluginassembly", id, new ColumnSet("content"));
+
+            return Convert.FromBase64String((string)response["content"]);
         }
 
         #endregion Methods

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/AppCode/AssemblyManager.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/AppCode/AssemblyManager.cs
@@ -45,7 +45,7 @@ namespace MsCrmTools.AssemblyRecoveryTool.AppCode
 
             var qe = new QueryExpression("pluginassembly")
             {
-                ColumnSet = new ColumnSet(true),
+                ColumnSet = new ColumnSet("name", "version", "publickeytoken"),
                 Distinct = false,
                 LinkEntities =
                 {

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/AppCode/AssemblyManager.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/AppCode/AssemblyManager.cs
@@ -3,6 +3,7 @@ using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace MsCrmTools.AssemblyRecoveryTool.AppCode
 {
@@ -36,7 +37,7 @@ namespace MsCrmTools.AssemblyRecoveryTool.AppCode
         #region Methods
 
         /// <summary>
-        /// Retrieve the assemblies for the specified irganization
+        /// Retrieve list of assemblies for the specified organization
         /// </summary>
         /// <returns>List of plugin assemblies</returns>
         public List<Entity> RetrieveAssemblies()
@@ -75,6 +76,16 @@ namespace MsCrmTools.AssemblyRecoveryTool.AppCode
             }
 
             return list;
+        }
+
+        /// <summary>
+        /// Retrieve binary assembly contents from specified organization
+        /// </summary>
+        /// <param name="id">Assembly identifier</param>
+        /// <returns></returns>
+        public byte[] RetrieveAssembly(Guid id)
+        {
+            throw new NotImplementedException();
         }
 
         #endregion Methods

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
@@ -140,7 +140,9 @@ namespace MsCrmTools.AssemblyRecoveryTool
                             : fbDialog.SelectedPath + "\\"),
                         item.Text);
 
-                        byte[] buffer = Convert.FromBase64String(item.Tag.ToString());
+                        // byte[] buffer = Convert.FromBase64String(item.Tag.ToString());
+                        byte[] buffer = Manager.RetrieveAssembly((Guid)item.Tag);
+
                         using (var writer = new BinaryWriter(File.Open(filename, FileMode.Create)))
                         {
                             writer.Write(buffer);

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
@@ -15,6 +15,12 @@ namespace MsCrmTools.AssemblyRecoveryTool
 {
     public partial class MainControl : PluginControlBase
     {
+        public AssemblyManager Manager
+        {
+            get;
+            private set;
+        }
+
         #region Constructor
 
         /// <summary>
@@ -77,13 +83,15 @@ namespace MsCrmTools.AssemblyRecoveryTool
 
         public void RetrieveAssemblies()
         {
+            // Initalizing plugin wide AssemblyManager instanace
+            Manager = new AssemblyManager(Service);
+
             WorkAsync(new WorkAsyncInfo
             {
                 Message = "Loading assemblies...",
                 Work = (bw, e) =>
                 {
-                    var aManager = new AssemblyManager(Service);
-                    e.Result = aManager.RetrieveAssemblies();
+                    e.Result = Manager.RetrieveAssemblies();
                 },
                 PostWorkCallBack = e =>
                 {

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
@@ -97,7 +97,7 @@ namespace MsCrmTools.AssemblyRecoveryTool
                         item.SubItems.Add(pAssembly["version"].ToString());
                         item.SubItems.Add(pAssembly["publickeytoken"].ToString());
 
-                        item.Tag = pAssembly["content"];
+                        //item.Tag = pAssembly["content"];
 
                         listView_Assemblies.Items.Add(item);
                     }

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
@@ -106,7 +106,6 @@ namespace MsCrmTools.AssemblyRecoveryTool
                         item.SubItems.Add(pAssembly["publickeytoken"].ToString());
 
                         item.Tag = pAssembly.Id;
-                        //item.Tag = pAssembly["content"];
 
                         listView_Assemblies.Items.Add(item);
                     }
@@ -140,7 +139,6 @@ namespace MsCrmTools.AssemblyRecoveryTool
                             : fbDialog.SelectedPath + "\\"),
                         item.Text);
 
-                        // byte[] buffer = Convert.FromBase64String(item.Tag.ToString());
                         byte[] buffer = Manager.RetrieveAssembly((Guid)item.Tag);
 
                         using (var writer = new BinaryWriter(File.Open(filename, FileMode.Create)))

--- a/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
+++ b/Plugins/MsCrmTools.AssemblyRecoveryTool/MainControl.cs
@@ -97,6 +97,7 @@ namespace MsCrmTools.AssemblyRecoveryTool
                         item.SubItems.Add(pAssembly["version"].ToString());
                         item.SubItems.Add(pAssembly["publickeytoken"].ToString());
 
+                        item.Tag = pAssembly.Id;
                         //item.Tag = pAssembly["content"];
 
                         listView_Assemblies.Items.Add(item);


### PR DESCRIPTION
`ART` now is not asking for binary contents of all assemblies, but only for these that user have chosen.

This actually significantly improves performance on systems with large number of assemblies.

