### PR TITLE
Hack for Early Bound Assemblies

### DIFF
--- a/XrmToolBox.Extensibility/PluginControlBase.cs
+++ b/XrmToolBox.Extensibility/PluginControlBase.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Reflection;
 using System.Windows.Forms;
+using Microsoft.Xrm.Sdk.Client;
 using XrmToolBox.Extensibility.Interfaces;
 
 namespace XrmToolBox.Extensibility
@@ -19,9 +20,10 @@ namespace XrmToolBox.Extensibility
     /// Fully Implements IMsCrmToolsPluginUserControl
     /// Defines an Event for when the Connection is Updated, useful if needing to know when to refresh a connection specific cache
     /// Fully Implements the IWorkerHost which provides a much nicer api for requesting a connection then calling a method
+    /// Allows for Specifying EarlyBound Proxy Types
     /// </summary>
     [PartNotDiscoverable]
-    public class PluginControlBase : UserControl, IXrmToolBoxPluginControl, IWorkerHost
+    public class PluginControlBase : UserControl, IXrmToolBoxPluginControl, IWorkerHost, IEarlyBoundProxy
     {
         public ConnectionDetail ConnectionDetail { get; set; }
 
@@ -338,5 +340,26 @@ namespace XrmToolBox.Extensibility
         }
 
         #endregion Connection Updated
+
+        #region EarlyBoundProxy
+
+        public Assembly GetEarlyBoundProxyAssembly() { return EarlyBoundTypeAssembly; }
+        protected Assembly EarlyBoundTypeAssembly { get; set; }
+        /// <summary>
+        /// Sets the type of the early bound assembly to be the assembly of the Context.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        protected void SetEarlyBoundAssemblyToContextAssembly<T>() where T : OrganizationServiceContext
+        {
+            var contextAssembly = typeof(T).Assembly;
+            if (contextAssembly == typeof(OrganizationServiceContext).Assembly)
+            {
+                throw new ArgumentException("The type of T inherit from OrganizationServiceContext");
+            }
+            EarlyBoundTypeAssembly = contextAssembly;
+        }
+
+
+        #endregion EarlyBoundProxy
     }
 }

--- a/XrmToolBox/AppDomainProxyTypeHack.cs
+++ b/XrmToolBox/AppDomainProxyTypeHack.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace XrmToolBox
+{
+    /// <summary>
+    /// This class/hack was created to address issues with the Xrm Sdk not allowing the earlybound type assembly to be specified.
+    /// https://github.com/MscrmTools/XrmToolBox/issues/353
+    /// </summary>
+    internal class AppDomainProxyTypeHack
+    {
+        public static void OverrideAppDomainKnownTypeInitialization()
+        {
+            InvokeAddingOfAssemblyLoadEventHandler();
+            RemoveAssemblyLoadEventHandler();
+        }
+
+        private static void InvokeAddingOfAssemblyLoadEventHandler()
+        {
+            var proxyTypesProvider = typeof(Microsoft.Xrm.Sdk.IOrganizationService).Assembly.GetType("Microsoft.Xrm.Sdk.KnownProxyTypesProvider");
+            if (proxyTypesProvider == null)
+            {
+                throw new Exception("AppDomainProxyTypeHack expected Microsoft.Xrm.Sdk.KnownProxyTypesProvider to exist in the same assembly as Microsoft.Xrm.Sdk.IOrganizationService, but it wasn't found!");
+            }
+            var getInstance = proxyTypesProvider.GetMethod("GetInstance", BindingFlags.NonPublic | BindingFlags.Static);
+            if (getInstance == null)
+            {
+                throw new Exception("AppDomainProxyTypeHack expected Microsoft.Xrm.Sdk.KnownProxyTypesProvider to contain a GetInstance(bool) method, but it wasn't found!");
+            }
+            getInstance.Invoke(null, BindingFlags.Static, null, new object[] { false }, null);
+        }
+
+        private static void RemoveAssemblyLoadEventHandler()
+        {
+            var assemblyLoadField = AppDomain.CurrentDomain.GetType().GetField("AssemblyLoad", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (assemblyLoadField == null)
+            {
+                throw new Exception("AppDomainProxyTypeHack expected AppDomain to contain an AssemblyLoad field, and none was found!");
+            }
+
+            var listOfDelegates = (AssemblyLoadEventHandler) assemblyLoadField.GetValue(AppDomain.CurrentDomain);
+            if (listOfDelegates == null)
+            {
+                throw new Exception("AppDomainProxyTypeHack expected Microsoft.Xrm.Sdk.KnownProxyTypesProvider.GetInstance(false) to add an Event handler to the AssemblyLoad Event, and none was found!");
+            }
+            var first = listOfDelegates.GetInvocationList().FirstOrDefault(i => i.Target.GetType().FullName == "Microsoft.Xrm.Sdk.AppDomainBasedKnownProxyTypesProvider");
+            if (first == null)
+            {
+                throw new Exception("AppDomainProxyTypeHack expected Microsoft.Xrm.Sdk.KnownProxyTypesProvider.GetInstance(false) to add an Event handler of type Microsoft.Xrm.Sdk.AppDomainBasedKnownProxyTypesProvider to the AssemblyLoad Event, but none was found!");
+            }
+            // Remove Event Handler
+            AppDomain.CurrentDomain.AssemblyLoad -= (AssemblyLoadEventHandler) first;
+        }
+    }
+}

--- a/XrmToolBox/MainForm.PluginsManagement.cs
+++ b/XrmToolBox/MainForm.PluginsManagement.cs
@@ -144,7 +144,12 @@ namespace XrmToolBox
                     var earlyBoundProxiedControl = pluginControl as IEarlyBoundProxy;
                     if (earlyBoundProxiedControl != null)
                     {
-                        clonedService.EnableProxyTypes(earlyBoundProxiedControl.GetEarlyBoundProxyAssembly());
+                        var assembly = earlyBoundProxiedControl.GetEarlyBoundProxyAssembly();
+                        if (assembly != null)
+                        {
+                            clonedService.EnableProxyTypes(assembly);
+                            AppDomainProxyTypeHack.RegisterAssembly(assembly);
+                        }
                     }
 
                     ((IXrmToolBoxPluginControl)pluginControl).UpdateConnection(clonedService, currentConnectionDetail);

--- a/XrmToolBox/Program.cs
+++ b/XrmToolBox/Program.cs
@@ -115,7 +115,7 @@ namespace XrmToolBox
                 }
 
                 SearchAndDestroyPluginsInRootFolder();
-
+                AppDomainProxyTypeHack.OverrideAppDomainKnownTypeInitialization();
                 CopyUpdatedPlugins();
 
                 Application.EnableVisualStyles();

--- a/XrmToolBox/XrmToolBox.csproj
+++ b/XrmToolBox/XrmToolBox.csproj
@@ -193,6 +193,7 @@
     <Compile Include="AppCode\PluginControlStatus.cs" />
     <Compile Include="AppCode\PluginUpdates.cs" />
     <Compile Include="AppCode\WebProxyHelper.cs" />
+    <Compile Include="AppDomainProxyTypeHack.cs" />
     <Compile Include="ConnectionParameterInfo.cs" />
     <Compile Include="Forms\NewVersionForm.cs">
       <SubType>Form</SubType>
@@ -339,7 +340,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_ConfigurationName="Release" />
+      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>


### PR DESCRIPTION
This change will allow the CRM ToolBox To Connect, even if multiple plugins are currently loaded with ProxyTypes Enabled.

It will allow for CrmContext interactions, but only if the plugin implements IEarlyBoundProxy, and only for one plugin assembly type per instance of XrmToolBox

Known Breaking Changes introduced:

If a plugin is using an OrganizationServiceContext without implementing IEarlyBoundProxy, it will fail upon attempts to interact to CRM via the OrganizationServiceContext.
Known Bugs introduced

If two plugins implement IEarlyBoundProxy, and define two different assemblies with at least one type of the same logical name, when the second plugin loads, and exception will be thrown.
For some reason the SetEarlyBoundAssembly method doesn't appear to be working with this change. It isn't calling the AssemblyBasedKnownProxyTypesProvider like I think it would, which means the Microsoft.Xrm.Sdk.Client.ProxyTypesBehavior's constructor is not getting called with a proxyTypesAssembly. I've added a RegisterAssembly call to load Types at the domain level, so at least the first request of an earlybound assembly will work.