### PR TITLE
MainForm Filter Tooltip: add "[by] description"

### DIFF
--- a/XrmToolBox/MainForm.Designer.cs
+++ b/XrmToolBox/MainForm.Designer.cs
@@ -243,7 +243,7 @@ namespace XrmToolBox
             this.tstxtFilterPlugin.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
             this.tstxtFilterPlugin.Name = "tstxtFilterPlugin";
             this.tstxtFilterPlugin.Size = new System.Drawing.Size(86, 32);
-            this.tstxtFilterPlugin.ToolTipText = "Filter by plugin name or company name";
+            this.tstxtFilterPlugin.ToolTipText = "Filter by plugin name, company name or description";
             this.tstxtFilterPlugin.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tstxtFilterPlugin_KeyDown);
             this.tstxtFilterPlugin.TextChanged += new System.EventHandler(this.tstxtFilterPlugin_TextChanged);
             // 


### PR DESCRIPTION
Commit 6c14257 added the plugins' descriptions as a date to filter by using the search box.
Yet it did not alter the correspoding tooltip text to reflect these changes.
That seemed to have caused confusion e.g. in issue #653.
This patch makes good for that by adding `"[the plugin] description"` as one of the enumerated dates to filter by.