### PR TITLE
Small fix to close the correct tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 /.vs/XrmToolBox/v15/sqlite3
+/.vs/XrmToolBox/v15/Server/sqlite3/storage.ide
+/.vs/XrmToolBox/v15/Server/sqlite3/db.lock
+/.vs/XrmToolBox/v15/Server/sqlite3/storage.ide-wal
+/.vs/XrmToolBox/v15/Server/sqlite3/storage.ide-shm

--- a/XrmToolBox/MainForm.cs
+++ b/XrmToolBox/MainForm.cs
@@ -719,7 +719,7 @@ namespace XrmToolBox
         {
             if (tabControl1.SelectedTab.TabIndex != 0)
             {
-                RequestCloseTab(tabControl1.TabPages[tabControl1.SelectedTab.TabIndex], new PluginCloseInfo(ToolBoxCloseReason.CloseCurrent));
+                RequestCloseTab(tabControl1.SelectedTab, new PluginCloseInfo(ToolBoxCloseReason.CloseCurrent));
             }
         }
 


### PR DESCRIPTION
Consider that you open two tabs with plugins, (can be the same plugin).
Then you close the first tab and then try to close the second.

Now that is fixed so the correct tab always is closed.