### PR TITLE
Prevent exception on update

### DIFF
--- a/XrmToolBox/New/NewVersionForm.cs
+++ b/XrmToolBox/New/NewVersionForm.cs
@@ -53,7 +53,10 @@ namespace XrmToolBox.New
 
                 var destinationFile = Path.Combine(destinationFolder, "XrmToolBox.AutoUpdater.exe");
 
-                File.Copy(updaterFile, destinationFile, true);
+				if (!updaterFile.Equals(destinationFile, StringComparison.OrdinalIgnoreCase)) 
+				{
+					File.Copy(updaterFile, destinationFile, true);
+				}
 
                 var args = Environment.GetCommandLineArgs().ToList();
 


### PR DESCRIPTION
The modified code will prevent an IOException when copying the updater if the source path is the same as the destination path.