### PR TITLE
Exception on update: handle case when path of xrmtoolbox.exe contains at leat one space

### DIFF
--- a/XrmToolBox.AutoUpdater/AutoUpdater.cs
+++ b/XrmToolBox.AutoUpdater/AutoUpdater.cs
@@ -83,26 +83,30 @@ namespace XrmToolBox.AutoUpdater
 
             args.RemoveAt(0);
             args.RemoveAt(0);
-
-            /* handle case where there is at leat one space in the path of the exe */
             var xtbPath = String.Empty;
-            foreach(var arg in args)
+
+            /* if path is already quoted */
+            if (args[0].StartsWith("\""))
             {
-                xtbPath = xtbPath + arg + " ";
-                /* the path is complete */
-                if (arg.ToLower().EndsWith("toolbox.exe"))
+                xtbPath = args.First();
+            }
+            else
+            {
+                /* handle case where there is at leat one space in the path of the exe */
+               
+                foreach (var arg in args)
                 {
-                    break;
+                    xtbPath = xtbPath + arg + " ";
+                    /* the path is complete */
+                    if (arg.ToLower().EndsWith("toolbox.exe"))
+                    {
+                        break;
+                    }
+
                 }
 
-            }
-
-            /* remove extra spaces */
-            xtbPath = xtbPath.Trim();
-
-
-            if (!xtbPath.StartsWith("\""))
-            {
+                /* remove extra spaces */
+                xtbPath = xtbPath.Trim();
                 xtbPath = $"\"{xtbPath}\"";
             }
 

--- a/XrmToolBox.AutoUpdater/AutoUpdater.cs
+++ b/XrmToolBox.AutoUpdater/AutoUpdater.cs
@@ -84,7 +84,22 @@ namespace XrmToolBox.AutoUpdater
             args.RemoveAt(0);
             args.RemoveAt(0);
 
-            var xtbPath = args.First();
+            /* handle case where there is at leat one space in the path of the exe */
+            var xtbPath = String.Empty;
+            foreach(var arg in args)
+            {
+                xtbPath = xtbPath + arg + " ";
+                /* the path is complete */
+                if (arg.ToLower().EndsWith("toolbox.exe"))
+                {
+                    break;
+                }
+
+            }
+
+            /* remove extra spaces */
+            xtbPath = xtbPath.Trim();
+
 
             if (!xtbPath.StartsWith("\""))
             {


### PR DESCRIPTION
When the path of XrmToolBox contains at leat one space, this path is splitted in many args. The path must be rebuilt before adding quote.
If not, an exception of type "not found "  will be thrown because the path is not complete.