### PR TITLE
Comparing string in lower case to avoid possible issues on some PCs

### DIFF
--- a/XrmToolBox/Program.cs
+++ b/XrmToolBox/Program.cs
@@ -157,7 +157,7 @@ namespace XrmToolBox
             var currentPluginsPath = Path.Combine(currentDirectory, "Plugins");
             if (Directory.Exists(currentPluginsPath))
             {
-                if (Path.GetFullPath(currentPluginsPath) != Path.GetFullPath(Paths.PluginsPath))
+                if (Path.GetFullPath(currentPluginsPath).ToLowerInvariant() != Path.GetFullPath(Paths.PluginsPath).ToLowerInvariant())
                 {
                     foreach (FileInfo fi in new DirectoryInfo(currentPluginsPath).GetFiles())
                     {

--- a/XrmToolBox/XrmToolBox.csproj
+++ b/XrmToolBox/XrmToolBox.csproj
@@ -423,65 +423,11 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="app.manifest" />
-    <None Include="bin\coretools\CrmSvcUtil.exe.config" />
-    <None Include="bin\coretools\LicenseTerms.docx" />
-    <None Include="bin\coretools\SolutionPackager.exe.config" />
-    <None Include="bin\Debug\XrmToolBox.exe.config" />
-    <None Include="bin\Debug\XrmToolBox.Extensibility.dll.config" />
-    <None Include="bin\Debug\XrmToolBox.PluginsStore.dll.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="bin\coretools\CrmSvcUtil.exe" />
-    <Content Include="bin\coretools\CrmSvcUtil.xml" />
-    <Content Include="bin\coretools\Microsoft.Crm.Sdk.Proxy.dll" />
-    <Content Include="bin\coretools\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
-    <Content Include="bin\coretools\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
-    <Content Include="bin\coretools\Microsoft.Rest.ClientRuntime.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Sdk.Deployment.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Sdk.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Tooling.Connector.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
-    <Content Include="bin\coretools\Newtonsoft.Json.dll" />
-    <Content Include="bin\coretools\Other Redistributable.txt" />
-    <Content Include="bin\coretools\SolutionPackager.exe" />
-    <Content Include="bin\coretools\System.ValueTuple.dll" />
-    <Content Include="bin\Debug\McTools.Xrm.Connection.dll" />
-    <Content Include="bin\Debug\McTools.Xrm.Connection.WinForms.dll" />
-    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.dll" />
-    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.xml" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.xml" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.dll" />
-    <Content Include="bin\Debug\Microsoft.Rest.ClientRuntime.dll" />
-    <Content Include="bin\Debug\Microsoft.Web.XmlTransform.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.Connector.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.Connector.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
-    <Content Include="bin\Debug\Newtonsoft.Json.dll" />
-    <Content Include="bin\Debug\Newtonsoft.Json.pdb" />
-    <Content Include="bin\Debug\Newtonsoft.Json.xml" />
-    <Content Include="bin\Debug\NuGet.Core.dll" />
-    <Content Include="bin\Debug\WeifenLuo.WinFormsUI.Docking.dll" />
-    <Content Include="bin\Debug\WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll" />
-    <Content Include="bin\Debug\XrmToolBox.AutoUpdater.exe" />
-    <Content Include="bin\Debug\XrmToolBox.exe" />
-    <Content Include="bin\Debug\XrmToolBox.Extensibility.dll" />
-    <Content Include="bin\Debug\XrmToolBox.Extensibility.pdb" />
-    <Content Include="bin\Debug\XrmToolBox.pdb" />
-    <Content Include="bin\Debug\XrmToolBox.PluginsStore.dll" />
-    <Content Include="bin\Debug\XrmToolBox.PluginsStore.pdb" />
-    <Content Include="bin\Release\XrmToolBox.exe" />
     <Content Include="favicon3Fr.ico" />
     <None Include="Resources\logo_0032.png" />
     <None Include="Resources\twitter.png" />
@@ -532,7 +478,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties BuildVersion_UpdateFileVersion="True" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_ConfigurationName="Release" />
+      <UserProperties BuildVersion_ConfigurationName="Release" BuildVersion_BuildVersioningStyle="None.YearStamp.MonthStamp.DayStamp" BuildVersion_UpdateAssemblyVersion="True" BuildVersion_UpdateFileVersion="True" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>


### PR DESCRIPTION
Trying to debug my plugin using `/overridepath:.` command line switch. `XTB` was giving me an error "File is used by another application" mentioning my plugin. That was very strange and I downloaded the source.

It turned out that `Path.GetFullPath` method resolved path differently depending upon was it initially given as relative or not. It was very small difference look:

```
c:\Innofactor\XrmToolBox.Plugin\Plugin\bin\Debug\Plugins
C:\Innofactor\XrmToolBox.Plugin\Plugin\bin\Debug\Plugins
```

But that difference let code start coping file to itself. And didn't let me debug. 

That PR will fix that behavior.