### PR TITLE
Open the Tool Library with a default search when an installed tool cannot be found

### DIFF
--- a/XrmToolBox.ToolLibrary/Forms/ToolLibraryForm.cs
+++ b/XrmToolBox.ToolLibrary/Forms/ToolLibraryForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -103,6 +103,11 @@ namespace XrmToolBox.ToolLibrary.Forms
             chkShowInstalled.Checked = (filters & PackageInstallAction.None) == PackageInstallAction.None;
             chkShowUpdates.Checked = (filters & PackageInstallAction.Update) == PackageInstallAction.Update;
             chkToInstall.Checked = (filters & PackageInstallAction.Install) == PackageInstallAction.Install;
+        }
+
+        public void SetSearchTerm(string searchTerm)
+        {
+            txtSearch.Text = searchTerm;
         }
 
         public void ShowUpdatesOnly()

--- a/XrmToolBox/New/EventArgs/PluginsListEventArgs.cs
+++ b/XrmToolBox/New/EventArgs/PluginsListEventArgs.cs
@@ -16,9 +16,19 @@ namespace XrmToolBox.New.EventArgs
         public PluginsListAction Action { get; }
     }
 
-    public enum PluginsListAction
+
+    public abstract class PluginsListAction { }
+
+    public class OpenPluginsStoreAction : PluginsListAction
     {
-        OpenPluginsStore,
-        ResetSearchFilter,
+        public OpenPluginsStoreAction(string searchTerm)
+        {
+            SearchTerm = searchTerm;
+        }
+
+        public string SearchTerm { get; }
     }
+
+    public class ResetSearchFilterAction : PluginsListAction { }
+
 }

--- a/XrmToolBox/New/NewForm.cs
+++ b/XrmToolBox/New/NewForm.cs
@@ -940,8 +940,8 @@ Would you like to reinstall last stable release of connection controls?";
         {
             switch (e.Action)
             {
-                case PluginsListAction.OpenPluginsStore:
-                    tsddbTools_DropDownItemClicked(sender, new ToolStripItemClickedEventArgs(pluginsStoreToolStripMenuItem));
+                case OpenPluginsStoreAction openStore:
+                    OpenPluginsStore(false, openStore.SearchTerm);
                     break;
             }
         }
@@ -1788,7 +1788,7 @@ Would you like to reinstall last stable release of connection controls?";
             worker.RunWorkerAsync();
         }
 
-        private void OpenPluginsStore(bool showUpdateOnly = false)
+        private void OpenPluginsStore(bool showUpdateOnly = false, string defaultSearchTerm = null)
         {
             if (pluginsForm == null)
             {
@@ -1858,6 +1858,10 @@ Would you like to reinstall last stable release of connection controls?";
                 }
             }
 
+            if (defaultSearchTerm != null)
+            {
+                libraryForm.SetSearchTerm(defaultSearchTerm);
+            } 
             libraryForm.Show(dpMain, DockState.Document);
         }
 

--- a/XrmToolBox/New/PluginsForm.cs
+++ b/XrmToolBox/New/PluginsForm.cs
@@ -681,7 +681,7 @@ namespace XrmToolBox.New
 
         private void pbOpenPluginsStore_Click(object sender, System.EventArgs e)
         {
-            ActionRequested?.Invoke(this, new PluginsListEventArgs(PluginsListAction.OpenPluginsStore));
+            ActionRequested?.Invoke(this, new PluginsListEventArgs(new OpenPluginsStoreAction(txtSearch.Text)));
         }
 
         private void PluginsForm_FormClosing(object sender, FormClosingEventArgs e)

--- a/XrmToolBox/New/PluginsForm2.cs
+++ b/XrmToolBox/New/PluginsForm2.cs
@@ -853,7 +853,7 @@ namespace XrmToolBox.New
 
         private void pbOpenPluginsStore_Click(object sender, System.EventArgs e)
         {
-            ActionRequested?.Invoke(this, new PluginsListEventArgs(PluginsListAction.OpenPluginsStore));
+            ActionRequested?.Invoke(this, new PluginsListEventArgs(new OpenPluginsStoreAction(txtSearch.Text)));
         }
 
         private void pbRefreshList_Click(object sender, System.EventArgs e)


### PR DESCRIPTION
This change will allow users to open the tool library from the "Open Tools Library" image button  with the search already set and filtered to their local search. This will hopefully provide a more streamlined experience to the user.
![image](https://github.com/MscrmTools/XrmToolBox/assets/16508508/a9293995-cff8-4bd9-8eab-ea4563ddd738)
![image](https://github.com/MscrmTools/XrmToolBox/assets/16508508/6cfd3af0-96de-44e5-a1a8-8667672c0d96)
