### PR TITLE
Update StoreFormFromPortal.cs - Issue #1331 Fix

### DIFF
--- a/XrmToolBox.PluginsStore/StoreFormFromPortal.cs
+++ b/XrmToolBox.PluginsStore/StoreFormFromPortal.cs
@@ -268,7 +268,11 @@ Current cache folder size: {size}MB";
 
         private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            Process.Start(llToolProjectUrl.Text);
+            if (Uri.IsWellFormedUriString(llToolProjectUrl.Text, UriKind.Absolute)) 
+            {
+                Process.Start(llToolProjectUrl.Text);
+            }
+            
         }
 
         private void llRatePlugin_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)


### PR DESCRIPTION
### What is being changed
Adding check to make sure loaded URLs from a plugins 'Project Url" are actual URLs when a user clicks on the loaded 'Project Url' within the Tool Library page. With this change, any user that clicks on a plugin 'Project Url' that fails the Uri check, the Process.Start() function will not be called. 

Found the code from: https://stackoverflow.com/questions/7578857/how-to-check-whether-a-string-is-a-valid-http-url

This will just prevent any non-urls from being executed in the Process.Start() function - preventing any potential for command injection found in Issue #1331. 

 
### How command injection occurs
Fundamentally command injection can occur when the 'Project Url' for a plugin contains commands instead of a URL and the user clicks on the 'Project Url' for a plugin in the Tool Library page. As the current version of XrmToolBox does not sanitize or check the URL from plugins loaded from the XrmToolBox portal, there are a few ways a malicious actor could utilize this flaw to execute arbitrary commands on users machines:

1. A malicious plugin with commands stored in its 'Project Url' is successfully added to the XrmToolBox Portal and loaded into users Tool Library. 
![image](https://github.com/MscrmTools/XrmToolBox/assets/65303833/82f9c498-db9c-4a30-a9cf-6fc0468f59af)

2. A man-in-the-middle attack occurs, intercepting the request to www.xrmtoolbox.com/_odata/plugins, and replacing specific or all mctools_projecturl data with arbitrary commands
![image](https://github.com/MscrmTools/XrmToolBox/assets/65303833/f8315e16-2177-4624-9fd1-975f7ff30dee)

What loaded commands will look like from a man-in-the-middle attack:
![image](https://github.com/MscrmTools/XrmToolBox/assets/65303833/6b689e87-f3de-4c7d-89ba-ae4cd15234b0)

