### PR TITLE
Only show the listed versions of the nuget packages. 

### DIFF
--- a/XrmToolBox.ToolLibrary/UserControls/ToolPackageProperties.cs
+++ b/XrmToolBox.ToolLibrary/UserControls/ToolPackageProperties.cs
@@ -101,7 +101,7 @@ namespace XrmToolBox.ToolLibrary.UserControls
 
                 var registrationData = httpClient.GetAsync(((JArray)jo["data"]).FirstOrDefault()["registration"].ToString()).GetAwaiter().GetResult().Content.ReadAsStringAsync().GetAwaiter().GetResult();
                 var rd = JObject.Parse(registrationData);
-                var versions = ((JArray)rd["items"]).SelectMany(va => (JArray)va["items"]);
+                var versions = ((JArray)rd["items"]).SelectMany(va => (JArray)va["items"]).Where(item => ((JObject)item["catalogEntry"])["listed"].Value<bool>() == true);
 
                 plugin.Versions = new List<XtbPluginVersion>();
 


### PR DESCRIPTION
Only show the listed versions of the NuGet packages. This allows creators to hide versions that are unstable / have bugs.

_For the [msftPACE.FlowOwnershipAudit](https://www.nuget.org/packages/msftPACE.FlowOwnershipAudit/) tool, our initial versions crash the toolbox. This is a fix where we have unlisted the invalid versions_