### PR TITLE
Bumped Microsoft.Bcl.AsyncInterfaces to version 9 to fix version mismatches when loading plugins.

### DIFF
--- a/XrmToolBox/XrmToolBox.csproj
+++ b/XrmToolBox/XrmToolBox.csproj
@@ -84,8 +84,8 @@
     <Reference Include="McTools.Xrm.Connection.WinForms, Version=1.2024.9.59, Culture=neutral, PublicKeyToken=f1559f79cf894e27, processorArchitecture=MSIL">
       <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2024.9.59\lib\net48\McTools.Xrm.Connection.WinForms.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=9.0.0.6, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.9.0.6\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.56\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/XrmToolBox/app.config
+++ b/XrmToolBox/app.config
@@ -98,6 +98,10 @@
         <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.6" newVersion="9.0.0.6" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.net>

--- a/XrmToolBox/packages.config
+++ b/XrmToolBox/packages.config
@@ -3,7 +3,7 @@
   <package id="DockPanelSuite" version="3.0.6" targetFramework="net462" />
   <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net462" />
   <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net462" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="9.0.6" targetFramework="net48" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.56" targetFramework="net48" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.34" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.56" targetFramework="net48" />


### PR DESCRIPTION
Since all XTB plugin assemblies are loaded into the same application domain, issues might arise if one plugin is loaded that has a dependency to an older version of [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces), and a subsequently loaded plugin has a dependency to a newer version.

An example - the [Plugin Registration](https://www.xrmtoolbox.com/plugins/Xrm.Sdk.PluginRegistration/) plugin references version 8.0.0.0 of Microsoft.Bcl.AsyncInterfaces. When this plugin is loaded, version 8 of the assembly is loaded into the Application Domain. Then, another plugin is loaded that references Microsoft.Bcl.AsyncInterfaces version 9.0.2, for example a plugin that uses the [Anthropic](https://www.nuget.org/packages/Anthropic) library.

Now two assemblies with different version are loaded into the same App Domain, which can be seen if dll binding is logged, using Fuslogvw.exe:

![image](https://github.com/user-attachments/assets/a6e07ca3-7698-496e-8c65-0e6325a543f8)

This can cause issues like MissingMethodException if the second plugin needs functionality not available in the older version of Microsoft.Bcl.AsyncInterfaces, as is described [here](https://learn.microsoft.com/en-us/dotnet/framework/deployment/best-practices-for-assembly-loading#avoid_loading_multiple_versions).

Bumping the version of Microsoft.Bcl.AsyncInterfaces to the latest version and adding binding redirects resolves this issue, and should also work for any existing plugin that references older versions because of backwards compatibility.





