### PR TITLE
fix: Ensure errors when extracting nuget package or installing plugin don't leave behind incomplete files.

### DIFF
--- a/XrmToolBox.PluginsStore/StoreForm - Copier.cs
+++ b/XrmToolBox.PluginsStore/StoreForm - Copier.cs
@@ -374,10 +374,30 @@ namespace XrmToolBox.PluginsStore
                     }
                     continue;
                 }
-                manager.InstallPackage(xtbPackage.Package, true, false);
 
                 var packageFolder = Path.Combine(nugetPluginsFolder,
                     xtbPackage.Package.Id + "." + xtbPackage.Package.Version);
+
+                try
+                {
+                    manager.InstallPackage(xtbPackage.Package, true, false);
+                }
+                catch
+                {
+                    // Clean up partially extracted package folder on failure
+                    if (Directory.Exists(packageFolder))
+                    {
+                        try
+                        {
+                            Directory.Delete(packageFolder, true);
+                        }
+                        catch
+                        {
+                            // Best effort cleanup - ignore errors during cleanup
+                        }
+                    }
+                    throw;
+                }
 
                 foreach (var fi in xtbPackage.Package.GetFiles())
                 {
@@ -425,6 +445,8 @@ namespace XrmToolBox.PluginsStore
             }
             else
             {
+                var copiedFiles = new List<string>();
+
                 foreach (var pu in updates.Plugins)
                 {
                     try
@@ -436,9 +458,26 @@ namespace XrmToolBox.PluginsStore
                             Directory.CreateDirectory(destinationDirectory);
                         }
                         File.Copy(pu.Source, pu.Destination, true);
+                        copiedFiles.Add(pu.Destination);
                     }
                     catch (Exception error)
                     {
+                        // Clean up files that were copied before the failure
+                        foreach (var copiedFile in copiedFiles)
+                        {
+                            try
+                            {
+                                if (File.Exists(copiedFile))
+                                {
+                                    File.Delete(copiedFile);
+                                }
+                            }
+                            catch
+                            {
+                                // Best effort cleanup - ignore errors during cleanup
+                            }
+                        }
+
                         MessageBox.Show(this,
                             "An error occured while copying files: " + error.Message +
                             "\r\n\r\nCopy has been aborted", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/XrmToolBox.PluginsStore/StoreFromPortal.cs
+++ b/XrmToolBox.PluginsStore/StoreFromPortal.cs
@@ -324,6 +324,8 @@ namespace XrmToolBox.PluginsStore
                 return false;
             }
 
+            var copiedFiles = new List<string>();
+
             foreach (var pu in updates.Plugins)
             {
                 try
@@ -340,9 +342,26 @@ namespace XrmToolBox.PluginsStore
                         Directory.CreateDirectory(destinationDirectory);
                     }
                     File.Copy(pu.Source, pu.Destination, true);
+                    copiedFiles.Add(pu.Destination);
                 }
                 catch (Exception error)
                 {
+                    // Clean up files that were copied before the failure
+                    foreach (var copiedFile in copiedFiles)
+                    {
+                        try
+                        {
+                            if (File.Exists(copiedFile))
+                            {
+                                File.Delete(copiedFile);
+                            }
+                        }
+                        catch
+                        {
+                            // Best effort cleanup - ignore errors during cleanup
+                        }
+                    }
+
                     MessageBox.Show("An error occured while copying files: " + error.Message +
                                     "\r\n\r\nCopy has been aborted", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
@@ -399,57 +418,76 @@ namespace XrmToolBox.PluginsStore
 
                     var packageFolder = Path.Combine(nugetPluginsFolder, $"{plugin.NugetId}.{version.Version}");
 
-                    using (PackageArchiveReader packageReader = new PackageArchiveReader(packageStream))
+                    try
                     {
-                        foreach (var packageFile in await packageReader.GetFilesAsync(cancellationToken))
+                        using (PackageArchiveReader packageReader = new PackageArchiveReader(packageStream))
                         {
-                            if (packageFile.ToLower().IndexOf("plugins/") >= 0)
+                            foreach (var packageFile in await packageReader.GetFilesAsync(cancellationToken))
                             {
-                                if (!Directory.Exists(packageFolder))
+                                if (packageFile.ToLower().IndexOf("plugins/") >= 0)
                                 {
-                                    Directory.CreateDirectory(packageFolder);
-                                }
-
-                                var relativeFilePath = packageFile.Remove(0, packageFile.ToLower().IndexOf("plugins/") + 8);
-                                var filePath = Path.Combine(packageFolder, relativeFilePath);
-                                var fi = new FileInfo(filePath);
-
-                                if (!Directory.Exists(fi.Directory.FullName))
-                                {
-                                    Directory.CreateDirectory(fi.Directory.FullName);
-                                }
-
-                                using (var fileStream = File.OpenWrite(filePath))
-                                using (var stream = await packageReader.GetStreamAsync(packageFile, cancellationToken))
-                                {
-                                    await stream.CopyToAsync(fileStream);
-                                }
-
-                                var destinationFile = Path.Combine(Paths.PluginsPath, relativeFilePath);
-
-                                // XrmToolBox restart is required when a plugin has to be
-                                // updated or when a new plugin shares files with other
-                                // plugin(s) already installed
-                                if (plugin.RequiresXtbRestart)
-                                {
-                                    pus.Plugins.Add(new PluginUpdate
+                                    if (!Directory.Exists(packageFolder))
                                     {
-                                        Source = filePath,
-                                        Destination = destinationFile,
-                                        RequireRestart = true
-                                    });
-                                }
-                                else if (plugin.Action == PackageInstallAction.Install)
-                                {
-                                    pus.Plugins.Add(new PluginUpdate
+                                        Directory.CreateDirectory(packageFolder);
+                                    }
+
+                                    var relativeFilePath = packageFile.Remove(0, packageFile.ToLower().IndexOf("plugins/") + 8);
+                                    var filePath = Path.Combine(packageFolder, relativeFilePath);
+                                    var fi = new FileInfo(filePath);
+
+                                    if (!Directory.Exists(fi.Directory.FullName))
                                     {
-                                        Source = filePath,
-                                        Destination = destinationFile,
-                                        RequireRestart = false
-                                    });
+                                        Directory.CreateDirectory(fi.Directory.FullName);
+                                    }
+
+                                    using (var fileStream = File.OpenWrite(filePath))
+                                    using (var stream = await packageReader.GetStreamAsync(packageFile, cancellationToken))
+                                    {
+                                        await stream.CopyToAsync(fileStream);
+                                    }
+
+                                    var destinationFile = Path.Combine(Paths.PluginsPath, relativeFilePath);
+
+                                    // XrmToolBox restart is required when a plugin has to be
+                                    // updated or when a new plugin shares files with other
+                                    // plugin(s) already installed
+                                    if (plugin.RequiresXtbRestart)
+                                    {
+                                        pus.Plugins.Add(new PluginUpdate
+                                        {
+                                            Source = filePath,
+                                            Destination = destinationFile,
+                                            RequireRestart = true
+                                        });
+                                    }
+                                    else if (plugin.Action == PackageInstallAction.Install)
+                                    {
+                                        pus.Plugins.Add(new PluginUpdate
+                                        {
+                                            Source = filePath,
+                                            Destination = destinationFile,
+                                            RequireRestart = false
+                                        });
+                                    }
                                 }
                             }
                         }
+                    }
+                    catch
+                    {
+                        // Clean up partially extracted package folder on failure
+                        if (Directory.Exists(packageFolder))
+                        {
+                            try
+                            {
+                                Directory.Delete(packageFolder, true);
+                            }
+                            catch
+                            {
+                                // Best effort cleanup - ignore errors during cleanup
+                            }
+                        }
+                        throw;
                     }
                 }
             }

--- a/XrmToolBox.ToolLibrary/ToolLibrary.cs
+++ b/XrmToolBox.ToolLibrary/ToolLibrary.cs
@@ -226,69 +226,88 @@ namespace XrmToolBox.ToolLibrary
             {
                 Directory.CreateDirectory(cachePackagePath);
 
-                Uri pathUri = new Uri(e.Plugin.DownloadUrl);
-                byte[] packageBytes;
-                if (pathUri.Scheme == "http" || pathUri.Scheme == "https")
+                try
                 {
-                    packageBytes = HttpClient.GetByteArrayAsync(e.DownloadUrl).GetAwaiter().GetResult();
-                }
-                else if (pathUri.Scheme == "file")
-                {
-                    packageBytes = File.ReadAllBytes(e.DownloadUrl);
-                }
-                else
-                {
-                    throw new Exception($"Unsupported file path scheme {pathUri.Scheme}");
-                }
-
-                using (var ms = new MemoryStream())
-                {
-                    ms.Write(packageBytes, 0, packageBytes.Length);
-                    var package = Package.Open(ms);
-
-                    bool found = false;
-
-                    foreach (var part in package.GetParts())
+                    Uri pathUri = new Uri(e.Plugin.DownloadUrl);
+                    byte[] packageBytes;
+                    if (pathUri.Scheme == "http" || pathUri.Scheme == "https")
                     {
-                        if (part.Uri.ToString().ToLower().IndexOf("/plugins/") < 0) continue;
+                        packageBytes = HttpClient.GetByteArrayAsync(e.DownloadUrl).GetAwaiter().GetResult();
+                    }
+                    else if (pathUri.Scheme == "file")
+                    {
+                        packageBytes = File.ReadAllBytes(e.DownloadUrl);
+                    }
+                    else
+                    {
+                        throw new Exception($"Unsupported file path scheme {pathUri.Scheme}");
+                    }
 
-                        found = true;
+                    using (var ms = new MemoryStream())
+                    {
+                        ms.Write(packageBytes, 0, packageBytes.Length);
+                        var package = Package.Open(ms);
 
-                        var fileName = part.Uri.ToString().Split(new string[] { "/Plugins/", "/plugins/" }, StringSplitOptions.RemoveEmptyEntries).Last();
-                        fullPath = Path.Combine(cachePackagePath, fileName);
-                        destinationFile = Path.Combine(Paths.PluginsPath, fileName);
+                        bool found = false;
 
-                        var directory = Path.GetDirectoryName(fullPath);
-                        if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
-
-                        using (var partStream = part.GetStream())
+                        foreach (var part in package.GetParts())
                         {
-                            using (var fileStream = File.Create(fullPath))
+                            if (part.Uri.ToString().ToLower().IndexOf("/plugins/") < 0) continue;
+
+                            found = true;
+
+                            var fileName = part.Uri.ToString().Split(new string[] { "/Plugins/", "/plugins/" }, StringSplitOptions.RemoveEmptyEntries).Last();
+                            fullPath = Path.Combine(cachePackagePath, fileName);
+                            destinationFile = Path.Combine(Paths.PluginsPath, fileName);
+
+                            var directory = Path.GetDirectoryName(fullPath);
+                            if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
+
+                            using (var partStream = part.GetStream())
                             {
-                                partStream.Seek(0, SeekOrigin.Begin);
-                                partStream.CopyTo(fileStream);
+                                using (var fileStream = File.Create(fullPath))
+                                {
+                                    partStream.Seek(0, SeekOrigin.Begin);
+                                    partStream.CopyTo(fileStream);
+                                }
+                            }
+
+                            // XrmToolBox restart is required when a plugin has to be
+                            // updated or when a new plugin shares files with other
+                            // plugin(s) already installed
+                            if (e.Plugin.RequiresXtbRestart || e.Plugin.Action == PackageInstallAction.Install)
+                            {
+                                pus.Plugins.Add(new PluginUpdate
+                                {
+                                    Name = e.Plugin.Name,
+                                    Source = fullPath,
+                                    Destination = destinationFile,
+                                    RequireRestart = e.Plugin.RequiresXtbRestart
+                                });
                             }
                         }
 
-                        // XrmToolBox restart is required when a plugin has to be
-                        // updated or when a new plugin shares files with other
-                        // plugin(s) already installed
-                        if (e.Plugin.RequiresXtbRestart || e.Plugin.Action == PackageInstallAction.Install)
+                        if (!found)
                         {
-                            pus.Plugins.Add(new PluginUpdate
-                            {
-                                Name = e.Plugin.Name,
-                                Source = fullPath,
-                                Destination = destinationFile,
-                                RequireRestart = e.Plugin.RequiresXtbRestart
-                            });
+                            throw new Exception("No plugin files found in package");
                         }
                     }
-
-                    if (!found)
+                }
+                catch
+                {
+                    // Clean up partially extracted package folder on failure
+                    if (Directory.Exists(cachePackagePath))
                     {
-                        throw new Exception("No plugin files found in package");
+                        try
+                        {
+                            Directory.Delete(cachePackagePath, true);
+                        }
+                        catch
+                        {
+                            // Best effort cleanup - ignore errors during cleanup
+                        }
                     }
+                    throw;
                 }
             }
             else


### PR DESCRIPTION
Whilst I was testing my new plugin I experienced an error during the NuGet package extraction. It was because of paths that were too long. (This is not XrmToolbox specific and I have resolved it). 

I noticed after the error, that the partially extracted folder in the `NugetPackages` folder was still present, and when I attempted the install again, the logic treated it as though it was successfully extracted - copying from there to `plugins` but with incomplete content. This caused the plugin to appear installed, but not work due to the missing files.

This PR adds some clean up in various places in case there's any IO error like the one I found. It ensures the partial folders get removed, so if the user retries, it will try again fully and not take incomplete files.

This PR was AI-assisted, but I have reviewed, revised and tested it with the version of my plugin that caused this error and observed that it corrects the behaviour.