### PR TITLE
Improve startup performance by loading UI and tools in parallel

### DIFF
--- a/XrmToolBox.ToolLibrary/Forms/ToolLibraryForm.cs
+++ b/XrmToolBox.ToolLibrary/Forms/ToolLibraryForm.cs
@@ -248,12 +248,12 @@ namespace XrmToolBox.ToolLibrary.Forms
             {
                 ((BackgroundWorker)s).ReportProgress(0, "Loading tools...");
 
-                if (toolLibrary.XrmToolBoxPlugins.Plugins.Count == 0 || isRefresh)
+                if (toolLibrary.XrmToolBoxPlugins == null || toolLibrary.XrmToolBoxPlugins.Plugins.Count == 0 || isRefresh)
                 {
                     toolLibrary.LoadTools().Wait();
                 }
 
-                if (imageCache.Cache.Count == 0)
+                if (imageCache.Cache.Count == 0 && toolLibrary.XrmToolBoxPlugins != null)
                 {
                     ((BackgroundWorker)s).ReportProgress(0, "Caching tools logo for first use. Please wait...");
 
@@ -274,7 +274,14 @@ namespace XrmToolBox.ToolLibrary.Forms
             {
                 if (evt.Error != null)
                 {
+                    lblLoading.Text = "Unable to load the tool library. Please check your network settings.";
                     MessageBox.Show(this, $"An error occured while loading tools: {evt.Error.ToString()}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
+
+                if (toolLibrary.XrmToolBoxPlugins == null || toolLibrary.Categories == null)
+                {
+                    lblLoading.Text = "No tools were returned by the tool library.";
                     return;
                 }
 

--- a/XrmToolBox/New/NewForm.cs
+++ b/XrmToolBox/New/NewForm.cs
@@ -397,7 +397,7 @@ Would you like to reinstall last stable release of connection controls?";
             Options.Instance.Save();
         }
 
-        private async void NewForm_Load(object sender, System.EventArgs e)
+        private void NewForm_Load(object sender, System.EventArgs e)
         {
             if (!Options.Instance.DoNotShowStartPage && startPage != null)
             {
@@ -409,6 +409,32 @@ Would you like to reinstall last stable release of connection controls?";
                 ((DockContent)pluginsForm).Show(dpMain, DockState.Document);
             }
 
+            // Adapt size of current form
+            if (Options.Instance.Size.IsMaximized)
+            {
+                WindowState = FormWindowState.Maximized;
+            }
+            else
+            {
+                Options.Instance.Size.ApplyFormSize(this);
+            }
+
+            // Hide & remove Welcome screen
+            WelcomeDialog.CloseForm();
+            Opacity = 100;
+            BringToTop();
+
+            CheckForEarlyBoundEntities();
+
+            LoadStartupData(sender);
+        }
+
+        /// <summary>
+        /// Startup work that queries web services. Runs after the main window is displayed so that
+        /// a slow or unavailable network does not delay it.
+        /// </summary>
+        private async void LoadStartupData(object sender)
+        {
             WebProxyHelper.ApplyProxy();
 
             await LoadStore();
@@ -448,29 +474,6 @@ Would you like to reinstall last stable release of connection controls?";
 
             tasks.ForEach(x => x.Start());
             await Task.WhenAll(tasks.ToArray());
-
-            // Adapt size of current form
-            if (Options.Instance.Size.IsMaximized)
-            {
-                Invoke(new Action(() =>
-                {
-                    WindowState = FormWindowState.Maximized;
-                }));
-            }
-            else
-            {
-                Options.Instance.Size.ApplyFormSize(this);
-            }
-
-            // Hide & remove Welcome screen
-            WelcomeDialog.CloseForm();
-            Invoke(new Action(() =>
-            {
-                Opacity = 100;
-                BringToTop();
-
-                CheckForEarlyBoundEntities();
-            }));
 
             try
             {

--- a/XrmToolBox/New/NewForm.cs
+++ b/XrmToolBox/New/NewForm.cs
@@ -437,6 +437,7 @@ Would you like to reinstall last stable release of connection controls?";
         {
             WebProxyHelper.ApplyProxy();
 
+            ccsb.SetMessage("Connecting to the Tool Library...");
             await LoadStore();
 
             var tasks = new List<Task>
@@ -472,6 +473,8 @@ Would you like to reinstall last stable release of connection controls?";
                 StartPluginWithoutConnection();
             }
 
+            ccsb.SetMessage("Checking for updates...");
+
             tasks.ForEach(x => x.Start());
             await Task.WhenAll(tasks.ToArray());
 
@@ -484,6 +487,7 @@ Would you like to reinstall last stable release of connection controls?";
 
                 if (store.PluginsCount == 0)
                 {
+                    ccsb.SetMessage("Loading the list of available tools...");
                     await store.LoadTools(false);
                 }
 
@@ -519,6 +523,7 @@ Would you like to reinstall last stable release of connection controls?";
                 }
 
                 // Prepare Categories
+                ccsb.SetMessage("Preparing categories...");
                 PrepareCategories();
             }
             catch (Exception error)
@@ -533,6 +538,8 @@ Would you like to reinstall last stable release of connection controls?";
             if (ctrls.Any()) Controls.Remove(ctrls.First());
             var ctrls2 = Controls.OfType<ConnectingCdsControl>();
             if (ctrls2.Any()) Controls.Remove(ctrls2.First());
+
+            ccsb.SetMessage(string.Empty);
         }
 
         private void PrepareCategories()

--- a/XrmToolBox/New/NewForm.cs
+++ b/XrmToolBox/New/NewForm.cs
@@ -1852,13 +1852,6 @@ Would you like to reinstall last stable release of connection controls?";
                     ItSecurityChecker isc = new ItSecurityChecker();
                     isc.LoadRepositories();
                     store = new ToolLibrary.ToolLibrary(Options.Instance, isc.Repositories);
-                    store.LoadTools().GetAwaiter().GetResult();
-                }
-
-                if (store.PluginsCount == 0 || store.Categories == null)
-                {
-                    MessageBox.Show(this, "Tool Library is not yet initialzed, please wait few seconds", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                    return;
                 }
 
                 libraryForm = new ToolLibraryForm((ToolLibrary.ToolLibrary)store, Options.Instance);

--- a/XrmToolBox/New/NewForm.cs
+++ b/XrmToolBox/New/NewForm.cs
@@ -67,8 +67,6 @@ namespace XrmToolBox.New
             SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
             SetStyle(ControlStyles.AllPaintingInWmPaint, true);
 
-            WelcomeDialog.ShowSplashScreen();
-
             SetTheme();
             dpMain.Theme.Extender.FloatWindowFactory = new CustomFloatWindowFactory();
 

--- a/XrmToolBox/PluginManagerExtended.cs
+++ b/XrmToolBox/PluginManagerExtended.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using XrmToolBox.Extensibility;
 using XrmToolBox.Extensibility.Interfaces;
@@ -83,6 +84,13 @@ namespace XrmToolBox
                 SynchronizingObject = parentForm
             };
             watcher.Created += watcher_EventRaised;
+
+            // DirectoryCatalog reads the plugin files one at a time, so pull them into the file
+            // cache in parallel first. Saves about a minute when the files are cold.
+            Parallel.ForEach(Directory.EnumerateFiles(PluginPath, "*.dll"), f =>
+            {
+                try { File.ReadAllBytes(f); } catch { }
+            });
 
             directoryCatalog = new DirectoryCatalog(PluginPath);
             var catalog = new AggregateCatalog();

--- a/XrmToolBox/Program.cs
+++ b/XrmToolBox/Program.cs
@@ -12,6 +12,7 @@ using System.Xml;
 using XrmToolBox.AppCode;
 using XrmToolBox.Extensibility;
 using XrmToolBox.Extensibility.Forms;
+using XrmToolBox.Forms;
 using XrmToolBox.New;
 using XrmToolBox.ToolLibrary.AppCode;
 using PluginUpdates = XrmToolBox.AppCode.PluginUpdates;
@@ -308,6 +309,11 @@ Please start XrmToolBox again to fix this problem",
             RemovePlugins();
             RunCommandIfAny();
 
+            // Must be called before the first window is created
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            WelcomeDialog.ShowSplashScreen();
+
             RedirectAssembly("Newtonsoft.Json");
             RedirectAssembly("McTools.Xrm.Connection");
             RedirectAssembly("McTools.Xrm.Connection.WinForms");
@@ -330,8 +336,6 @@ Please start XrmToolBox again to fix this problem",
             OptimizeConnectionSettings();
             SetProxy();
 
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new NewForm(args));
         }
 


### PR DESCRIPTION
The recent issue with the route hosting the tool library going down highlighted that a lot of work was being done during the initial splash screen that was not strictly necessary for the day to day use of XrmToolBox. The happy path for most use cases is opening the application then launching a pre-installed tool, not going to the store to install new ones. And yet users must wait for a lot of network traffic (checking for updates, loading the tool library) before they can use a tool.
This PR moves some of those tasks that were blocking into background tasks.

The other speed up change in this PR is to load the plug-in DLLs into memory when the full tool rescan happens, this cuts the file system IO and antivirus scan time by a lot going from ~100s to ~22s on 86 tools.

Overall the changes here speed up launch time substantially on cold starts, and slightly faster best case (Web calls being fast) and much better in the worst case (Web calls being down or slow)